### PR TITLE
Move over Diff code from DataModel

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
 	},
 	"require": {
 		"php": ">=5.3.0",
-		"wikibase/data-model": "~3.0"
+		"wikibase/data-model": "~3.0",
+		"diff/diff": "~2.0"
 	},
 	"require-dev": {
 		"squizlabs/php_codesniffer": "~2.1",
@@ -35,7 +36,7 @@
 	"scripts": {
 		"test": [
 			"composer validate --no-interaction",
-			"phpunit"
+			"phpunit --coverage-text=/dev/null"
 		],
 		"cs": [
 			"composer phpcs",
@@ -49,7 +50,7 @@
 			"vendor/bin/phpcs src/* tests/* --standard=phpcs.xml --extensions=php -sp"
 		],
 		"phpmd": [
-			"vendor/bin/phpmd src/,tests/ text phpmd.xml"
+			"vendor/bin/phpmd src/,tests/unit/ text phpmd.xml"
 		]
 	}
 }

--- a/src/Diff/EntityDiff.php
+++ b/src/Diff/EntityDiff.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Diff;
+
+use Diff\DiffOp\Diff\Diff;
+use Diff\DiffOp\DiffOp;
+use Wikibase\DataModel\Entity\Item;
+
+/**
+ * Represents a diff between two entities.
+ *
+ * @since 1.0
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class EntityDiff extends Diff {
+
+	/**
+	 * @param string $entityType
+	 * @param DiffOp[] $operations
+	 *
+	 * @return self
+	 */
+	public static function newForType( $entityType, $operations = array() ) {
+		if ( $entityType === Item::ENTITY_TYPE ) {
+			return new ItemDiff( $operations );
+		}
+		else {
+			return new EntityDiff( $operations );
+		}
+	}
+
+	/**
+	 * @param DiffOp[] $operations
+	 */
+	public function __construct( array $operations = array() ) {
+		$this->fixSubstructureDiff( $operations, 'aliases' );
+		$this->fixSubstructureDiff( $operations, 'label' );
+		$this->fixSubstructureDiff( $operations, 'description' );
+		$this->fixSubstructureDiff( $operations, 'claim' );
+
+		parent::__construct( $operations, true );
+	}
+
+	/**
+	 * Checks the type of a substructure diff, and replaces it if needed.
+	 * This is needed for backwards compatibility with old versions of
+	 * MapDiffer: As of commit ff65735a125e, MapDiffer may generate atomic diffs for
+	 * substructures even in recursive mode (bug 51363).
+	 *
+	 * @param array &$operations All change ops; This is a reference, so the
+	 *        substructure diff can be replaced if need be.
+	 * @param string $key The key of the substructure
+	 */
+	protected function fixSubstructureDiff( array &$operations, $key ) {
+		if ( !isset( $operations[$key] ) ) {
+			return;
+		}
+
+		if ( !$operations[$key] instanceof Diff ) {
+			$warning = "Invalid substructure diff for key $key: " . get_class( $operations[$key] );
+
+			if ( function_exists( 'wfLogWarning' ) ) {
+				wfLogWarning( $warning );
+			} else {
+				trigger_error( $warning, E_USER_WARNING );
+			}
+
+			// We could look into the atomic diff, see if it uses arrays as values,
+			// and construct a new Diff according to these values. But since the
+			// actual old behavior of MapDiffer didn't cause that to happen, let's
+			// just use an empty diff, which is what MapDiffer should have returned
+			// in the actual broken case mentioned in bug 51363.
+			$operations[$key] = new Diff( array(), true );
+		}
+	}
+
+	/**
+	 * Returns a Diff object with the aliases differences.
+	 *
+	 * @return Diff
+	 */
+	public function getAliasesDiff() {
+		return isset( $this['aliases'] ) ? $this['aliases'] : new Diff( array(), true );
+	}
+
+	/**
+	 * Returns a Diff object with the labels differences.
+	 *
+	 * @return Diff
+	 */
+	public function getLabelsDiff() {
+		return isset( $this['label'] ) ? $this['label'] : new Diff( array(), true );
+	}
+
+	/**
+	 * Returns a Diff object with the descriptions differences.
+	 *
+	 * @return Diff
+	 */
+	public function getDescriptionsDiff() {
+		return isset( $this['description'] ) ? $this['description'] : new Diff( array(), true );
+	}
+
+	/**
+	 * Returns a Diff object with the claim differences.
+	 *
+	 * @return Diff
+	 */
+	public function getClaimsDiff() {
+		return isset( $this['claim'] ) ? $this['claim'] : new Diff( array(), true );
+	}
+
+	/**
+	 * Returns if there are any changes (equivalent to: any differences between the entities).
+	 *
+	 * @return bool
+	 */
+	public function isEmpty() {
+		return $this->getLabelsDiff()->isEmpty()
+			&& $this->getDescriptionsDiff()->isEmpty()
+			&& $this->getAliasesDiff()->isEmpty()
+			&& $this->getClaimsDiff()->isEmpty();
+	}
+
+	/**
+	 * @see DiffOp::getType
+	 *
+	 * @return string
+	 */
+	public function getType() {
+		return 'diff/entity';
+	}
+
+}

--- a/src/Diff/EntityDiffer.php
+++ b/src/Diff/EntityDiffer.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Diff;
+
+use InvalidArgumentException;
+use RuntimeException;
+use Wikibase\DataModel\Entity\EntityDocument;
+
+/**
+ * @since 1.0
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class EntityDiffer {
+
+	/**
+	 * @var EntityDifferStrategy[]
+	 */
+	private $differStrategies;
+
+	public function __construct() {
+		$this->registerEntityDifferStrategy( new ItemDiffer() );
+		$this->registerEntityDifferStrategy( new PropertyDiffer() );
+	}
+
+	public function registerEntityDifferStrategy( EntityDifferStrategy $differStrategy ) {
+		$this->differStrategies[] = $differStrategy;
+	}
+
+	/**
+	 * @param EntityDocument $from
+	 * @param EntityDocument $to
+	 *
+	 * @return EntityDiff
+	 * @throws InvalidArgumentException
+	 * @throws RuntimeException
+	 */
+	public function diffEntities( EntityDocument $from, EntityDocument $to ) {
+		$this->assertTypesMatch( $from, $to );
+
+		return $this->getDiffStrategy( $from->getType() )->diffEntities( $from, $to );
+	}
+
+	private function assertTypesMatch( EntityDocument $from, EntityDocument $to ) {
+		if ( $from->getType() !== $to->getType() ) {
+			throw new InvalidArgumentException( 'Can only diff two entities of the same type' );
+		}
+	}
+
+	private function getDiffStrategy( $entityType ) {
+		foreach ( $this->differStrategies as $diffStrategy ) {
+			if ( $diffStrategy->canDiffEntityType( $entityType ) ) {
+				return $diffStrategy;
+			}
+		}
+
+		throw new RuntimeException( 'Diffing the provided types of entities is not supported' );
+	}
+
+	/**
+	 * @param EntityDocument $entity
+	 *
+	 * @return EntityDiff
+	 * @throws InvalidArgumentException
+	 */
+	public function getConstructionDiff( EntityDocument $entity ) {
+		return $this->getDiffStrategy( $entity->getType() )->getConstructionDiff( $entity );
+	}
+
+	/**
+	 * @param EntityDocument $entity
+	 *
+	 * @return EntityDiff
+	 * @throws InvalidArgumentException
+	 */
+	public function getDestructionDiff( EntityDocument $entity ) {
+		return $this->getDiffStrategy( $entity->getType() )->getDestructionDiff( $entity );
+	}
+
+}

--- a/src/Diff/EntityDifferStrategy.php
+++ b/src/Diff/EntityDifferStrategy.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Diff;
+
+use InvalidArgumentException;
+use Wikibase\DataModel\Entity\EntityDocument;
+
+/**
+ * @since 1.0
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+interface EntityDifferStrategy {
+
+	/**
+	 * @param string $entityType
+	 *
+	 * @return boolean
+	 */
+	public function canDiffEntityType( $entityType );
+
+	/**
+	 * @param EntityDocument $from
+	 * @param EntityDocument $to
+	 *
+	 * @return EntityDiff
+	 * @throws InvalidArgumentException
+	 */
+	public function diffEntities( EntityDocument $from, EntityDocument $to );
+
+	/**
+	 * @param EntityDocument $entity
+	 *
+	 * @return EntityDiff
+	 * @throws InvalidArgumentException
+	 */
+	public function getConstructionDiff( EntityDocument $entity );
+
+	/**
+	 * @param EntityDocument $entity
+	 *
+	 * @return EntityDiff
+	 * @throws InvalidArgumentException
+	 */
+	public function getDestructionDiff( EntityDocument $entity );
+
+}

--- a/src/Diff/EntityPatcher.php
+++ b/src/Diff/EntityPatcher.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Diff;
+
+use InvalidArgumentException;
+use RuntimeException;
+use Wikibase\DataModel\Entity\EntityDocument;
+
+/**
+ * @since 1.0
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ * @author Christoph Fischer < christoph.fischer@wikimedia.de >
+ */
+class EntityPatcher {
+
+	/**
+	 * @var EntityPatcherStrategy[]
+	 */
+	private $patcherStrategies;
+
+	public function __construct() {
+		$this->registerEntityPatcherStrategy( new ItemPatcher() );
+		$this->registerEntityPatcherStrategy( new PropertyPatcher() );
+	}
+
+	public function registerEntityPatcherStrategy( EntityPatcherStrategy $patcherStrategy ) {
+		$this->patcherStrategies[] = $patcherStrategy;
+	}
+
+	/**
+	 * @param EntityDocument $entity
+	 * @param EntityDiff $patch
+	 *
+	 * @throws InvalidArgumentException
+	 * @throws RuntimeException
+	 */
+	public function patchEntity( EntityDocument $entity, EntityDiff $patch ) {
+		$this->getPatcherStrategy( $entity->getType() )->patchEntity( $entity, $patch );
+	}
+
+	private function getPatcherStrategy( $entityType ) {
+		foreach ( $this->patcherStrategies as $patcherStrategy ) {
+			if ( $patcherStrategy->canPatchEntityType( $entityType ) ) {
+				return $patcherStrategy;
+			}
+		}
+
+		throw new RuntimeException( 'Patching the provided types of entities is not supported' );
+	}
+
+}

--- a/src/Diff/EntityPatcherStrategy.php
+++ b/src/Diff/EntityPatcherStrategy.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Diff;
+
+use InvalidArgumentException;
+use Wikibase\DataModel\Entity\EntityDocument;
+
+/**
+ * @since 1.0
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+interface EntityPatcherStrategy {
+
+	/**
+	 * @param string $entityType
+	 *
+	 * @return boolean
+	 */
+	public function canPatchEntityType( $entityType );
+
+	/**
+	 * @param EntityDocument $entity
+	 * @param EntityDiff $patch
+	 *
+	 * @throws InvalidArgumentException
+	 */
+	public function patchEntity( EntityDocument $entity, EntityDiff $patch );
+
+}

--- a/src/Diff/Internal/FingerprintPatcher.php
+++ b/src/Diff/Internal/FingerprintPatcher.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Diff\Internal;
+
+use Diff\DiffOp\Diff\Diff;
+use Diff\Patcher\MapPatcher;
+use InvalidArgumentException;
+use Wikibase\DataModel\Services\Diff\EntityDiff;
+use Wikibase\DataModel\Term\AliasGroup;
+use Wikibase\DataModel\Term\AliasGroupList;
+use Wikibase\DataModel\Term\Fingerprint;
+use Wikibase\DataModel\Term\TermList;
+
+/**
+ * Package private.
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class FingerprintPatcher {
+
+	/**
+	 * @var MapPatcher
+	 */
+	private $patcher;
+
+	public function __construct() {
+		$this->patcher = new MapPatcher();
+	}
+
+	/**
+	 * @param Fingerprint $fingerprint
+	 * @param EntityDiff $patch
+	 *
+	 * @throws InvalidArgumentException
+	 */
+	public function patchFingerprint( Fingerprint $fingerprint, EntityDiff $patch ) {
+		$labels = $this->patcher->patch(
+			$fingerprint->getLabels()->toTextArray(),
+			$patch->getLabelsDiff()
+		);
+
+		$fingerprint->setLabels( $this->newTermListFromArray( $labels ) );
+
+		$descriptions = $this->patcher->patch(
+			$fingerprint->getDescriptions()->toTextArray(),
+			$patch->getDescriptionsDiff()
+		);
+
+		$fingerprint->setDescriptions( $this->newTermListFromArray( $descriptions ) );
+
+		$this->patchAliases( $fingerprint, $patch->getAliasesDiff() );
+	}
+
+	private function newTermListFromArray( $termArray ) {
+		$termList = new TermList();
+
+		foreach ( $termArray as $language => $labelText ) {
+			$termList->setTextForLanguage( $language, $labelText );
+		}
+
+		return $termList;
+	}
+
+	private function patchAliases( Fingerprint $fingerprint, Diff $aliasesDiff ) {
+		$patchedAliases = $this->patcher->patch(
+			$this->getAliasesArrayForPatching( $fingerprint->getAliasGroups() ),
+			$aliasesDiff
+		);
+
+		$fingerprint->setAliasGroups( $this->getAliasesFromArrayForPatching( $patchedAliases ) );
+	}
+
+	private function getAliasesArrayForPatching( AliasGroupList $aliases ) {
+		$textLists = array();
+
+		/**
+		 * @var AliasGroup $aliasGroup
+		 */
+		foreach ( $aliases as $languageCode => $aliasGroup ) {
+			$textLists[$languageCode] = $aliasGroup->getAliases();
+		}
+
+		return $textLists;
+	}
+
+	private function getAliasesFromArrayForPatching( array $patchedAliases ) {
+		$aliases = new AliasGroupList();
+
+		foreach( $patchedAliases as $languageCode => $aliasList ) {
+			$aliases->setAliasesForLanguage( $languageCode, $aliasList );
+		}
+
+		return $aliases;
+	}
+
+}

--- a/src/Diff/Internal/SiteLinkListPatcher.php
+++ b/src/Diff/Internal/SiteLinkListPatcher.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Diff\Internal;
+
+use Diff\DiffOp\Diff\Diff;
+use Diff\Patcher\ListPatcher;
+use Diff\Patcher\MapPatcher;
+use InvalidArgumentException;
+use Wikibase\DataModel\Entity\ItemId;
+use Wikibase\DataModel\SiteLink;
+use Wikibase\DataModel\SiteLinkList;
+
+/**
+ * Package private.
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ * @author Thiemo Mättig
+ */
+class SiteLinkListPatcher {
+
+	/**
+	 * @var MapPatcher
+	 */
+	private $patcher;
+
+	public function __construct() {
+		$this->patcher = new MapPatcher( false, new ListPatcher() );
+	}
+
+	/**
+	 * @param SiteLinkList $siteLinks
+	 * @param Diff $patch
+	 *
+	 * @return SiteLinkList
+	 * @throws InvalidArgumentException
+	 */
+	public function getPatchedSiteLinkList( SiteLinkList $siteLinks, Diff $patch ) {
+		$baseData = $this->getSiteLinksInDiffFormat( $siteLinks );
+		$patchedData = $this->patcher->patch( $baseData, $patch );
+
+		$patchedSiteLinks = new SiteLinkList();
+
+		foreach ( $patchedData as $siteId => $siteLinkData ) {
+			if ( array_key_exists( 'name', $siteLinkData ) ) {
+				$patchedSiteLinks->addNewSiteLink(
+					$siteId,
+					$siteLinkData['name'],
+					$this->getBadgesFromSiteLinkData( $siteLinkData )
+				);
+			}
+		}
+
+		return $patchedSiteLinks;
+	}
+
+	private function getBadgesFromSiteLinkData( array $siteLinkData ) {
+		if ( !array_key_exists( 'badges', $siteLinkData ) ) {
+			return null;
+		}
+
+		return array_map(
+			function( $idSerialization ) {
+				return new ItemId( $idSerialization );
+			},
+			$siteLinkData['badges']
+		);
+	}
+
+	private function getSiteLinksInDiffFormat( SiteLinkList $siteLinks ) {
+		$linksInDiffFormat = array();
+
+		/**
+		 * @var SiteLink $siteLink
+		 */
+		foreach ( $siteLinks as $siteLink ) {
+			$linksInDiffFormat[$siteLink->getSiteId()] = array(
+				'name' => $siteLink->getPageName(),
+				'badges' => array_map(
+					function( ItemId $itemId ) {
+						return $itemId->getSerialization();
+					},
+					$siteLink->getBadges()
+				)
+			);
+		}
+
+		return $linksInDiffFormat;
+	}
+
+}

--- a/src/Diff/Internal/StatementListDiffer.php
+++ b/src/Diff/Internal/StatementListDiffer.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Diff\Internal;
+
+use Diff\Differ\MapDiffer;
+use Diff\DiffOp\Diff\Diff;
+use UnexpectedValueException;
+use Wikibase\DataModel\Statement\Statement;
+use Wikibase\DataModel\Statement\StatementList;
+
+/**
+ * Package private.
+ *
+ * @since 1.0
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class StatementListDiffer {
+
+	/**
+	 * @since 1.0
+	 *
+	 * @param StatementList $fromStatements
+	 * @param StatementList $toStatements
+	 *
+	 * @return Diff
+	 * @throws UnexpectedValueException
+	 */
+	public function getDiff( StatementList $fromStatements, StatementList $toStatements ) {
+		return new Diff(
+			$this->newDiffer()->doDiff(
+				$this->toDiffArray( $fromStatements ),
+				$this->toDiffArray( $toStatements )
+			),
+			true
+		);
+	}
+
+	private function newDiffer() {
+		$differ = new MapDiffer();
+
+		$differ->setComparisonCallback( function( Statement $fromStatement, Statement $toStatement ) {
+			return $fromStatement->equals( $toStatement );
+		} );
+
+		return $differ;
+	}
+
+	private function toDiffArray( StatementList $statementList ) {
+		$statementArray = array();
+
+		/**
+		 * @var Statement $statement
+		 */
+		foreach ( $statementList as $statement ) {
+			$statementArray[$statement->getGuid()] = $statement;
+		}
+
+		return $statementArray;
+	}
+
+}

--- a/src/Diff/Internal/StatementListPatcher.php
+++ b/src/Diff/Internal/StatementListPatcher.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Diff\Internal;
+
+use Diff\Comparer\CallbackComparer;
+use Diff\DiffOp\Diff\Diff;
+use Diff\Patcher\MapPatcher;
+use InvalidArgumentException;
+use Wikibase\DataModel\Statement\Statement;
+use Wikibase\DataModel\Statement\StatementList;
+
+/**
+ * Package private.
+ *
+ * @since 1.0
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class StatementListPatcher {
+
+	/**
+	 * @var MapPatcher
+	 */
+	private $patcher;
+
+	public function __construct() {
+		$this->patcher = new MapPatcher();
+
+		$this->patcher->setValueComparer( new CallbackComparer(
+			function( Statement $firstStatement, Statement $secondStatement ) {
+				return $firstStatement->equals( $secondStatement );
+			}
+		) );
+	}
+
+	/**
+	 * @param StatementList $statements
+	 * @param Diff $patch
+	 *
+	 * @throws InvalidArgumentException
+	 * @return StatementList
+	 */
+	public function getPatchedStatementList( StatementList $statements, Diff $patch ) {
+		$statementsByGuid = array();
+
+		/**
+		 * @var Statement $statement
+		 */
+		foreach ( $statements as $statement ) {
+			$statementsByGuid[$statement->getGuid()] = $statement;
+		}
+
+		$patchedList = new StatementList();
+
+		foreach ( $this->patcher->patch( $statementsByGuid, $patch ) as $statement ) {
+			$patchedList->addStatement( $statement );
+		}
+
+		return $patchedList;
+	}
+
+}

--- a/src/Diff/ItemDiff.php
+++ b/src/Diff/ItemDiff.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Diff;
+
+use Diff\DiffOp\Diff\Diff;
+use Diff\DiffOp\DiffOp;
+
+/**
+ * Represents a diff between two Item instances.
+ *
+ * @since 1.0
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class ItemDiff extends EntityDiff {
+
+	/**
+	 * @param DiffOp[] $operations
+	 */
+	public function __construct( array $operations = array() ) {
+		$this->fixSubstructureDiff( $operations, 'links' );
+
+		parent::__construct( $operations );
+	}
+
+	/**
+	 * Returns a Diff object with the sitelink differences.
+	 *
+	 * @return Diff
+	 */
+	public function getSiteLinkDiff() {
+		return isset( $this['links'] ) ? $this['links'] : new Diff( array(), true );
+	}
+
+	/**
+	 * @see EntityDiff::isEmpty
+	 *
+	 * @return bool
+	 */
+	public function isEmpty() {
+		return parent::isEmpty()
+			&& $this->getSiteLinkDiff()->isEmpty();
+	}
+
+	/**
+	 * @see DiffOp::getType
+	 *
+	 * @return string
+	 */
+	public function getType() {
+		return 'diff/item';
+	}
+
+}

--- a/src/Diff/ItemDiffer.php
+++ b/src/Diff/ItemDiffer.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Diff;
+
+use Diff\Differ\MapDiffer;
+use InvalidArgumentException;
+use Wikibase\DataModel\Entity\EntityDocument;
+use Wikibase\DataModel\Entity\Item;
+use Wikibase\DataModel\Entity\ItemId;
+use Wikibase\DataModel\SiteLink;
+use Wikibase\DataModel\Statement\StatementListDiffer;
+
+/**
+ * @since 1.0
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class ItemDiffer implements EntityDifferStrategy {
+
+	/**
+	 * @var MapDiffer
+	 */
+	private $recursiveMapDiffer;
+
+	/**
+	 * @var StatementListDiffer
+	 */
+	private $statementListDiffer;
+
+	public function __construct() {
+		$this->recursiveMapDiffer = new MapDiffer( true );
+		$this->statementListDiffer = new StatementListDiffer();
+	}
+
+	/**
+	 * @param string $entityType
+	 *
+	 * @return bool
+	 */
+	public function canDiffEntityType( $entityType ) {
+		return $entityType === 'item';
+	}
+
+	/**
+	 * @param EntityDocument $from
+	 * @param EntityDocument $to
+	 *
+	 * @return ItemDiff
+	 * @throws InvalidArgumentException
+	 */
+	public function diffEntities( EntityDocument $from, EntityDocument $to ) {
+		$this->assertIsItem( $from );
+		$this->assertIsItem( $to );
+
+		return $this->diffItems( $from, $to );
+	}
+
+	private function assertIsItem( EntityDocument $item ) {
+		if ( !( $item instanceof Item ) ) {
+			throw new InvalidArgumentException( '$item must be an instance of Item' );
+		}
+	}
+
+	public function diffItems( Item $from, Item $to ) {
+		$diffOps = $this->recursiveMapDiffer->doDiff(
+			$this->toDiffArray( $from ),
+			$this->toDiffArray( $to )
+		);
+
+		$diffOps['claim'] = $this->statementListDiffer->getDiff( $from->getStatements(), $to->getStatements() );
+
+		return new ItemDiff( $diffOps );
+	}
+
+	private function toDiffArray( Item $item ) {
+		$array = array();
+
+		$array['aliases'] = $item->getFingerprint()->getAliasGroups()->toTextArray();
+		$array['label'] = $item->getFingerprint()->getLabels()->toTextArray();
+		$array['description'] = $item->getFingerprint()->getDescriptions()->toTextArray();
+		$array['links'] = $this->getLinksInDiffFormat( $item );
+
+		return $array;
+	}
+
+	private function getLinksInDiffFormat( Item $item ) {
+		$links = array();
+
+		/**
+		 * @var SiteLink $siteLink
+		 */
+		foreach ( $item->getSiteLinkList() as $siteLink ) {
+			$links[$siteLink->getSiteId()] = array(
+				'name' => $siteLink->getPageName(),
+				'badges' => array_map(
+					function( ItemId $id ) {
+						return $id->getSerialization();
+					},
+					$siteLink->getBadges()
+				)
+			);
+		}
+
+		return $links;
+	}
+
+	/**
+	 * @param EntityDocument $entity
+	 *
+	 * @return ItemDiff
+	 * @throws InvalidArgumentException
+	 */
+	public function getConstructionDiff( EntityDocument $entity ) {
+		$this->assertIsItem( $entity );
+		return $this->diffEntities( new Item(), $entity );
+	}
+
+	/**
+	 * @param EntityDocument $entity
+	 *
+	 * @return ItemDiff
+	 * @throws InvalidArgumentException
+	 */
+	public function getDestructionDiff( EntityDocument $entity ) {
+		$this->assertIsItem( $entity );
+		return $this->diffEntities( $entity, new Item() );
+	}
+
+}

--- a/src/Diff/ItemPatcher.php
+++ b/src/Diff/ItemPatcher.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Diff;
+
+use InvalidArgumentException;
+use Wikibase\DataModel\Entity\EntityDocument;
+use Wikibase\DataModel\Entity\Item;
+use Wikibase\DataModel\Services\Diff\Internal\FingerprintPatcher;
+use Wikibase\DataModel\Services\Diff\Internal\SiteLinkListPatcher;
+use Wikibase\DataModel\Services\Diff\Internal\StatementListPatcher;
+
+/**
+ * @since 1.0
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class ItemPatcher implements EntityPatcherStrategy {
+
+	/**
+	 * @var FingerprintPatcher
+	 */
+	private $fingerprintPatcher;
+
+	/**
+	 * @var StatementListPatcher
+	 */
+	private $statementListPatcher;
+
+	/**
+	 * @var SiteLinkListPatcher
+	 */
+	private $siteLinkListPatcher;
+
+	public function __construct() {
+		$this->fingerprintPatcher = new FingerprintPatcher();
+		$this->statementListPatcher = new StatementListPatcher();
+		$this->siteLinkListPatcher = new SiteLinkListPatcher();
+	}
+
+	/**
+	 * @param string $entityType
+	 *
+	 * @return boolean
+	 */
+	public function canPatchEntityType( $entityType ) {
+		return $entityType === 'item';
+	}
+
+	/**
+	 * @param EntityDocument $entity
+	 * @param EntityDiff $patch
+	 *
+	 * @return Item
+	 * @throws InvalidArgumentException
+	 */
+	public function patchEntity( EntityDocument $entity, EntityDiff $patch ) {
+		$this->assertIsItem( $entity );
+
+		$this->patchItem( $entity, $patch );
+	}
+
+	private function assertIsItem( EntityDocument $item ) {
+		if ( !( $item instanceof Item ) ) {
+			throw new InvalidArgumentException( '$item must be an instance of Item' );
+		}
+	}
+
+	private function patchItem( Item $item, EntityDiff $patch ) {
+		$this->fingerprintPatcher->patchFingerprint( $item->getFingerprint(), $patch );
+
+		if ( $patch instanceof ItemDiff ) {
+			$item->setSiteLinkList( $this->siteLinkListPatcher->getPatchedSiteLinkList(
+				$item->getSiteLinkList(),
+				$patch->getSiteLinkDiff()
+			) );
+		}
+
+		$item->setStatements( $this->statementListPatcher->getPatchedStatementList(
+			$item->getStatements(),
+			$patch->getClaimsDiff()
+		) );
+	}
+
+}

--- a/src/Diff/PropertyDiffer.php
+++ b/src/Diff/PropertyDiffer.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Diff;
+
+use Diff\Differ\MapDiffer;
+use InvalidArgumentException;
+use Wikibase\DataModel\Entity\EntityDocument;
+use Wikibase\DataModel\Entity\Property;
+use Wikibase\DataModel\Services\Diff\Internal\StatementListDiffer;
+use Wikibase\DataModel\Statement\StatementList;
+
+/**
+ * @since 1.0
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class PropertyDiffer implements EntityDifferStrategy {
+
+	/**
+	 * @var MapDiffer
+	 */
+	private $recursiveMapDiffer;
+
+	/**
+	 * @var StatementListDiffer
+	 */
+	private $statementListDiffer;
+
+	public function __construct() {
+		$this->recursiveMapDiffer = new MapDiffer( true );
+		$this->statementListDiffer = new StatementListDiffer();
+	}
+
+	/**
+	 * @param string $entityType
+	 *
+	 * @return bool
+	 */
+	public function canDiffEntityType( $entityType ) {
+		return $entityType === 'property';
+	}
+
+	/**
+	 * @param EntityDocument $from
+	 * @param EntityDocument $to
+	 *
+	 * @return EntityDiff
+	 * @throws InvalidArgumentException
+	 */
+	public function diffEntities( EntityDocument $from, EntityDocument $to ) {
+		$this->assertIsProperty( $from );
+		$this->assertIsProperty( $to );
+
+		return $this->diffProperties( $from, $to );
+	}
+
+	private function assertIsProperty( EntityDocument $property ) {
+		if ( !( $property instanceof Property ) ) {
+			throw new InvalidArgumentException( '$property must be an instance of Property' );
+		}
+	}
+
+	public function diffProperties( Property $from, Property $to ) {
+		$diffOps = $this->diffPropertyArrays(
+			$this->toDiffArray( $from ),
+			$this->toDiffArray( $to )
+		);
+
+		$diffOps['claim'] = $this->statementListDiffer->getDiff( $from->getStatements(), $to->getStatements() );
+
+		return new EntityDiff( $diffOps );
+	}
+
+	private function diffPropertyArrays( array $from, array $to ) {
+		return $this->recursiveMapDiffer->doDiff( $from, $to );
+	}
+
+	private function toDiffArray( Property $property ) {
+		$array = array();
+
+		$array['aliases'] = $property->getFingerprint()->getAliasGroups()->toTextArray();
+		$array['label'] = $property->getFingerprint()->getLabels()->toTextArray();
+		$array['description'] = $property->getFingerprint()->getDescriptions()->toTextArray();
+
+		return $array;
+	}
+
+	/**
+	 * @param EntityDocument $entity
+	 *
+	 * @return EntityDiff
+	 * @throws InvalidArgumentException
+	 */
+	public function getConstructionDiff( EntityDocument $entity ) {
+		$this->assertIsProperty( $entity );
+
+		/** @var Property $entity */
+		$diffOps = $this->diffPropertyArrays( array(), $this->toDiffArray( $entity ) );
+		$diffOps['claim'] = $this->statementListDiffer->getDiff( new StatementList(), $entity->getStatements() );
+
+		return new EntityDiff( $diffOps );
+	}
+
+	/**
+	 * @param EntityDocument $entity
+	 *
+	 * @return EntityDiff
+	 * @throws InvalidArgumentException
+	 */
+	public function getDestructionDiff( EntityDocument $entity ) {
+		$this->assertIsProperty( $entity );
+
+		/** @var Property $entity */
+		$diffOps = $this->diffPropertyArrays( $this->toDiffArray( $entity ), array() );
+		$diffOps['claim'] = $this->statementListDiffer->getDiff( $entity->getStatements(), new StatementList() );
+
+		return new EntityDiff( $diffOps );
+	}
+
+}

--- a/src/Diff/PropertyPatcher.php
+++ b/src/Diff/PropertyPatcher.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Diff;
+
+use InvalidArgumentException;
+use Wikibase\DataModel\Entity\EntityDocument;
+use Wikibase\DataModel\Entity\Property;
+use Wikibase\DataModel\Services\Diff\Internal\FingerprintPatcher;
+use Wikibase\DataModel\Statement\StatementListPatcher;
+
+/**
+ * @since 1.0
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class PropertyPatcher implements EntityPatcherStrategy {
+
+	/**
+	 * @var FingerprintPatcher
+	 */
+	private $fingerprintPatcher;
+
+	/**
+	 * @var StatementListPatcher
+	 */
+	private $statementListPatcher;
+
+	public function __construct() {
+		$this->fingerprintPatcher = new FingerprintPatcher();
+		$this->statementListPatcher = new StatementListPatcher();
+	}
+
+	/**
+	 * @param string $entityType
+	 *
+	 * @return boolean
+	 */
+	public function canPatchEntityType( $entityType ) {
+		return $entityType === 'property';
+	}
+
+	/**
+	 * @param EntityDocument $entity
+	 * @param EntityDiff $patch
+	 *
+	 * @return Property
+	 * @throws InvalidArgumentException
+	 */
+	public function patchEntity( EntityDocument $entity, EntityDiff $patch ) {
+		$this->assertIsProperty( $entity );
+
+		$this->patchProperty( $entity, $patch );
+	}
+
+	private function assertIsProperty( EntityDocument $property ) {
+		if ( !( $property instanceof Property ) ) {
+			throw new InvalidArgumentException( '$property must be an instance of Property' );
+		}
+	}
+
+	private function patchProperty( Property $property, EntityDiff $patch ) {
+		$this->fingerprintPatcher->patchFingerprint( $property->getFingerprint(), $patch );
+
+		$property->setStatements( $this->statementListPatcher->getPatchedStatementList(
+			$property->getStatements(),
+			$patch->getClaimsDiff()
+		) );
+	}
+
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -21,5 +21,6 @@ if ( !is_readable( __DIR__ . '/../vendor/autoload.php' ) ) {
 $autoLoader = require_once __DIR__ . '/../vendor/autoload.php';
 
 $autoLoader->addPsr4( 'Wikibase\\DataModel\\Services\\Tests\\', __DIR__ . '/unit/' );
+$autoLoader->addPsr4( 'Wikibase\\DataModel\\Services\\Fixtures\\', __DIR__ . '/fixtures/' );
 
 unset( $autoLoader );

--- a/tests/fixtures/EntityOfUnknownType.php
+++ b/tests/fixtures/EntityOfUnknownType.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Fixtures;
+
+use Wikibase\DataModel\Entity\EntityDocument;
+
+/**
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class EntityOfUnknownType implements EntityDocument {
+
+	public function getId() {
+		return null;
+	}
+
+	public function getType() {
+		return 'unknown-entity-type';
+	}
+
+	public function setId( $id ) {
+	}
+
+}

--- a/tests/unit/Diff/EntityDiffOldTest.php
+++ b/tests/unit/Diff/EntityDiffOldTest.php
@@ -1,0 +1,213 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Tests\Diff;
+
+use Wikibase\DataModel\Entity\Entity;
+use Wikibase\DataModel\Entity\Item;
+use Wikibase\DataModel\Entity\Property;
+
+/**
+ * @covers Wikibase\DataModel\Services\Diff\EntityDiff
+ *
+ * @licence GNU GPL v2+
+ * @author Daniel Kinzler
+ * @author Jens Ohlig <jens.ohlig@wikimedia.de>
+ */
+abstract class EntityDiffOldTest extends \PHPUnit_Framework_TestCase {
+
+	private static function newEntity( $entityType ) {
+		switch ( $entityType ) {
+			case Item::ENTITY_TYPE:
+				return new Item();
+			case Property::ENTITY_TYPE:
+				return Property::newFromType( 'string' );
+			default:
+				throw new \RuntimeException( "unknown entity type: $entityType" );
+		}
+	}
+
+	public static function generateApplyData( $entityType ) {
+		$tests = array();
+
+		// #0: add label
+		$a = self::newEntity( $entityType );
+		$a->setLabel( 'en', 'Test' );
+
+		$b = $a->copy();
+		$b->setLabel( 'de', 'Test' );
+
+		$tests[] = array( $a, $b );
+
+		// #1: remove label
+		$a = self::newEntity( $entityType );
+		$a->setLabel( 'en', 'Test' );
+		$a->setLabel( 'de', 'Test' );
+
+		$b = self::newEntity( $entityType );
+		$b->setLabel( 'de', 'Test' );
+
+		$tests[] = array( $a, $b );
+
+		// #2: change label
+		$a = self::newEntity( $entityType );
+		$a->setLabel( 'en', 'Test' );
+
+		$b = $a->copy();
+		$b->setLabel( 'en', 'Test!!!' );
+
+		// #3: add description ------------------------------
+		$a = self::newEntity( $entityType );
+		$a->setDescription( 'en', 'Test' );
+
+		$b = $a->copy();
+		$b->setDescription( 'de', 'Test' );
+
+		$tests[] = array( $a, $b );
+
+		// #4: remove description
+		$a = self::newEntity( $entityType );
+		$a->setDescription( 'en', 'Test' );
+		$a->setDescription( 'de', 'Test' );
+
+		$b = $a->copy();
+		$b->removeDescription( 'en' );
+
+		$tests[] = array( $a, $b );
+
+		// #5: change description
+		$a = self::newEntity( $entityType );
+		$a->setDescription( 'en', 'Test' );
+
+		$b = $a->copy();
+		$b->setDescription( 'en', 'Test!!!' );
+
+		$tests[] = array( $a, $b );
+
+		// #6: add alias ------------------------------
+		$a = self::newEntity( $entityType );
+		$a->addAliases( 'en', array( 'Foo', 'Bar' ) );
+
+		$b = $a->copy();
+		$b->addAliases( 'en', array( 'Quux' ) );
+
+		$tests[] = array( $a, $b );
+
+		// #7: add alias language
+		$a = self::newEntity( $entityType );
+		$a->addAliases( 'en', array( 'Foo', 'Bar' ) );
+
+		$b = $a->copy();
+		$b->addAliases( 'de', array( 'Quux' ) );
+
+		$tests[] = array( $a, $b );
+
+		// #8: remove alias
+		$a = self::newEntity( $entityType );
+		$a->addAliases( 'en', array( 'Foo', 'Bar' ) );
+
+		$b = $a->copy();
+		$b->removeAliases( 'en', array( 'Foo' ) );
+
+		$tests[] = array( $a, $b );
+
+		// #9: remove alias language
+		$a = self::newEntity( $entityType );
+
+		$b = $a->copy();
+		$b->addAliases( 'en', array( 'Foo', 'Bar' ) );
+		$b->removeAliases( 'en', array( 'Foo', 'Bar' ) );
+
+		$tests[] = array( $a, $b );
+		return $tests;
+	}
+
+	/**
+	 *
+	 * @dataProvider provideApplyData
+	 */
+	public function testApply( Entity $a, Entity $b ) {
+		$a->patch( $a->getDiff( $b ) );
+		$this->assertTrue( $a->getFingerprint()->equals( $b->getFingerprint() ) );
+	}
+
+	public function provideConflictDetection() {
+		$cases = array();
+
+		// #0: adding a label where there was none before
+		$base = self::newEntity( Item::ENTITY_TYPE );
+		$current = $base->copy();
+
+		$new = $base->copy();
+		$new->setLabel( 'en', 'TEST' );
+
+		$cases[] = array(
+			$base,
+			$current,
+			$new,
+			0 // there should eb no conflicts.
+		);
+
+		// #1: adding an alias where there was none before
+		$base = self::newEntity( Item::ENTITY_TYPE );
+		$current = $base;
+
+		$new = $base->copy();
+		$new->addAliases( 'en', array( 'TEST' ) );
+
+		$cases[] = array(
+			$base,
+			$current,
+			$new,
+			0 // there should eb no conflicts.
+		);
+
+		// #2: adding an alias where there already was one before
+		$base = self::newEntity( Item::ENTITY_TYPE );
+		$base->addAliases( 'en', array( 'Foo' ) );
+		$current = $base;
+
+		$new = $base->copy();
+		$new->addAliases( 'en', array( 'Bar' ) );
+
+		$cases[] = array(
+			$base,
+			$current,
+			$new,
+			0 // there should be no conflicts.
+		);
+
+		// #3: adding an alias where there already was one in another language
+		$base = self::newEntity( Item::ENTITY_TYPE );
+		$base->addAliases( 'en', array( 'Foo' ) );
+		$current = $base;
+
+		$new = $base->copy();
+		$new->addAliases( 'de', array( 'Bar' ) );
+
+		$cases[] = array(
+			$base,
+			$current,
+			$new,
+			0 // there should be no conflicts.
+		);
+
+		return $cases;
+	}
+
+	/**
+	 * @dataProvider provideConflictDetection
+	 */
+	public function testConflictDetection( Entity $base, Entity $current, Entity $new, $expectedConflicts ) {
+		$patch = $base->getDiff( $new );
+
+		$patchedCurrent = $current->copy();
+		$patchedCurrent->patch( $patch );
+
+		$cleanPatch = $base->getDiff( $patchedCurrent );
+
+		$conflicts = $patch->count() - $cleanPatch->count();
+
+		$this->assertEquals( $expectedConflicts, $conflicts, "check number of conflicts detected" );
+	}
+
+}

--- a/tests/unit/Diff/EntityDiffTest.php
+++ b/tests/unit/Diff/EntityDiffTest.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Tests\Diff;
+
+use Diff\DiffOp\Diff\Diff;
+use Diff\DiffOp\DiffOpAdd;
+use Diff\DiffOp\DiffOpChange;
+use Diff\DiffOp\DiffOpRemove;
+use Wikibase\DataModel\Services\Diff\EntityDiff;
+use Wikibase\DataModel\Services\Diff\Internal\StatementListDiffer;
+use Wikibase\DataModel\Snak\PropertyNoValueSnak;
+use Wikibase\DataModel\Statement\Statement;
+use Wikibase\DataModel\Statement\StatementList;
+
+/**
+ * @covers Wikibase\DataModel\Services\Diff\EntityDiff
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class EntityDiffTest extends \PHPUnit_Framework_TestCase {
+
+	public function isEmptyProvider() {
+		$argLists = array();
+
+		$argLists[] = array( array(), true );
+
+		$fields = array( 'aliases', 'label', 'description', 'claim' );
+
+		foreach ( $fields as $field ) {
+			$argLists[] = array( array( $field => new Diff( array() ) ), true );
+		}
+
+		$diffOps = array();
+
+		foreach ( $fields as $field ) {
+			$diffOps[$field] = new Diff( array() );
+		}
+
+		$argLists[] = array( $diffOps, true );
+
+		foreach ( $fields as $field ) {
+			$argLists[] = array( array( $field => new Diff( array( new DiffOpAdd( 42 ) ) ) ), false );
+		}
+
+		return $argLists;
+	}
+
+	/**
+	 * @dataProvider isEmptyProvider
+	 * @param Diff[] $diffOps
+	 * @param bool $isEmpty
+	 */
+	public function testIsEmpty( array $diffOps, $isEmpty ) {
+		$diff = new EntityDiff( $diffOps );
+		$this->assertEquals( $isEmpty, $diff->isEmpty() );
+	}
+
+	public function diffProvider() {
+		$diffs = array();
+
+		$diffOps = array(
+			'label' => new Diff( array(
+				'en' => new DiffOpAdd( 'foobar' ),
+				'de' => new DiffOpRemove( 'onoez' ),
+				'nl' => new DiffOpChange( 'foo', 'bar' ),
+			), true )
+		);
+
+		$diffs[] = new EntityDiff( $diffOps );
+
+		$diffOps['description'] = new Diff( array(
+			'en' => new DiffOpAdd( 'foobar' ),
+			'de' => new DiffOpRemove( 'onoez' ),
+			'nl' => new DiffOpChange( 'foo', 'bar' ),
+		), true );
+
+		$diffs[] = new EntityDiff( $diffOps );
+
+		$diffOps['aliases'] = new Diff( array(
+			'en' => new Diff( array( new DiffOpAdd( 'foobar' ), new DiffOpRemove( 'onoez' ) ), false ),
+			'de' => new Diff( array( new DiffOpRemove( 'foo' ) ), false ),
+		), true );
+
+		$diffs[] = new EntityDiff( $diffOps );
+
+		$statement = new Statement( new PropertyNoValueSnak( 42 ) );
+		$statement->setGuid( 'EntityDiffTest$foo' );
+
+		$statementListDiffer = new StatementListDiffer();
+		$diffOps['claim'] = $statementListDiffer->getDiff(
+			new StatementList( $statement ),
+			new StatementList()
+		);
+
+		$diffs[] = new EntityDiff( $diffOps );
+
+		$argLists = array();
+
+		foreach ( $diffs as $diff ) {
+			$argLists[] = array( $diff );
+		}
+
+		return $argLists;
+	}
+
+	/**
+	 * @dataProvider diffProvider
+	 */
+	public function testGetClaimsDiff( EntityDiff $entityDiff ) {
+		$diff = $entityDiff->getClaimsDiff();
+
+		$this->assertInstanceOf( 'Diff\Diff', $diff );
+		$this->assertTrue( $diff->isAssociative() );
+
+		foreach ( $diff as $diffOp ) {
+			$this->assertTrue( $diffOp instanceof DiffOpAdd || $diffOp instanceof DiffOpRemove );
+
+			$statement = $diffOp instanceof DiffOpAdd ? $diffOp->getNewValue() : $diffOp->getOldValue();
+			$this->assertInstanceOf( 'Wikibase\DataModel\Statement\Statement', $statement );
+		}
+	}
+
+	/**
+	 * @dataProvider diffProvider
+	 */
+	public function testGetDescriptionsDiff( EntityDiff $entityDiff ) {
+		$diff = $entityDiff->getDescriptionsDiff();
+
+		$this->assertInstanceOf( 'Diff\Diff', $diff );
+		$this->assertTrue( $diff->isAssociative() );
+	}
+
+	/**
+	 * @dataProvider diffProvider
+	 */
+	public function testGetLabelsDiff( EntityDiff $entityDiff ) {
+		$diff = $entityDiff->getLabelsDiff();
+
+		$this->assertInstanceOf( 'Diff\Diff', $diff );
+		$this->assertTrue( $diff->isAssociative() );
+	}
+
+	/**
+	 * @dataProvider diffProvider
+	 */
+	public function testGetAliasesDiff( EntityDiff $entityDiff ) {
+		$diff = $entityDiff->getAliasesDiff();
+
+		$this->assertInstanceOf( 'Diff\Diff', $diff );
+		$this->assertTrue( $diff->isAssociative() );
+	}
+
+}

--- a/tests/unit/Diff/EntityDifferTest.php
+++ b/tests/unit/Diff/EntityDifferTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Tests\Diff;
+
+use Wikibase\DataModel\Entity\Item;
+use Wikibase\DataModel\Entity\Property;
+use Wikibase\DataModel\Services\Fixtures\EntityOfUnknownType;
+use Wikibase\DataModel\Services\Diff\EntityDiffer;
+
+/**
+ * @covers Wikibase\DataModel\Services\Diff\EntityDiffer
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class EntityDifferTest extends \PHPUnit_Framework_TestCase {
+
+	public function testGivenUnknownEntityType_exceptionIsThrown() {
+		$differ = new EntityDiffer();
+
+		$this->setExpectedException( 'RuntimeException' );
+		$differ->diffEntities( new EntityOfUnknownType(), new EntityOfUnknownType() );
+	}
+
+	public function testGivenEntitiesWithDifferentTypes_exceptionIsThrown() {
+		$differ = new EntityDiffer();
+
+		$this->setExpectedException( 'InvalidArgumentException' );
+		$differ->diffEntities( new Item(), Property::newFromType( 'string' ) );
+	}
+
+	public function testGivenTwoEmptyItems_emptyItemDiffIsReturned() {
+		$differ = new EntityDiffer();
+
+		$diff = $differ->diffEntities( new Item(), new Item() );
+
+		$this->assertInstanceOf( 'Wikibase\DataModel\Services\Diff\ItemDiff', $diff );
+		$this->assertTrue( $diff->isEmpty() );
+	}
+
+	public function testGivenUnknownEntityType_getConstructionDiffThrowsException() {
+		$differ = new EntityDiffer();
+
+		$this->setExpectedException( 'RuntimeException' );
+		$differ->getConstructionDiff( new EntityOfUnknownType() );
+	}
+
+	public function testGivenUnknownEntityType_getDestructionDiffThrowsException() {
+		$differ = new EntityDiffer();
+
+		$this->setExpectedException( 'RuntimeException' );
+		$differ->getDestructionDiff( new EntityOfUnknownType() );
+	}
+
+}

--- a/tests/unit/Diff/EntityPatcherTest.php
+++ b/tests/unit/Diff/EntityPatcherTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Tests\Diff;
+
+use Wikibase\DataModel\Entity\Item;
+use Wikibase\DataModel\Entity\ItemId;
+use Wikibase\DataModel\Services\Diff\EntityDiff;
+use Wikibase\DataModel\Services\Diff\EntityPatcher;
+use Wikibase\DataModel\Services\Diff\ItemDiff;
+use Wikibase\DataModel\Services\Fixtures\EntityOfUnknownType;
+
+/**
+ * @covers Wikibase\DataModel\Services\Diff\EntityPatcher
+ *
+ * @licence GNU GPL v2+
+ * @author Christoph Fischer < christoph.fischer@wikimedia.de >
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class EntityPatcherTest extends \PHPUnit_Framework_TestCase {
+
+	/**
+	 * @dataProvider itemProvider
+	 */
+	public function testGivenEmptyDiffItemRemainsUnchanged( Item $item ) {
+		$patcher = new EntityPatcher();
+
+		$patchedEntity = $item->copy();
+		$patcher->patchEntity( $patchedEntity, new ItemDiff() );
+
+		$this->assertEquals( $item, $patchedEntity );
+	}
+
+	public function itemProvider() {
+		$argLists = array();
+
+		$nonEmptyItem = new Item( new ItemId( 'Q2' ) );
+
+		$argLists[] = array( new Item() );
+		$argLists[] = array( $nonEmptyItem );
+
+		return $argLists;
+	}
+
+	public function testGivenNonSupportedEntity_exceptionIsThrown() {
+		$patcher = new EntityPatcher();
+
+		$this->setExpectedException( 'RuntimeException' );
+		$patcher->patchEntity( new EntityOfUnknownType(), new EntityDiff() );
+	}
+
+}

--- a/tests/unit/Diff/Internal/FingerprintPatcherTest.php
+++ b/tests/unit/Diff/Internal/FingerprintPatcherTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Tests\Diff\Internal;
+
+use Diff\DiffOp\Diff\Diff;
+use Diff\DiffOp\DiffOpAdd;
+use Diff\DiffOp\DiffOpChange;
+use Wikibase\DataModel\Services\Diff\EntityDiff;
+use Wikibase\DataModel\Services\Diff\Internal\FingerprintPatcher;
+use Wikibase\DataModel\Term\Fingerprint;
+
+/**
+ * @covers Wikibase\DataModel\Services\Diff\Internal\FingerprintPatcher
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class FingerprintPatcherTest extends \PHPUnit_Framework_TestCase {
+
+	public function testGivenEmptyDiff_fingerprintIsReturnedAsIs() {
+		$fingerprint = $this->newSimpleFingerprint();
+
+		$this->assertFingerprintResultsFromPatch( $fingerprint, $fingerprint, new EntityDiff() );
+	}
+
+	private function newSimpleFingerprint() {
+		$fingerprint = new Fingerprint();
+
+		$fingerprint->setLabel( 'en', 'foo' );
+		$fingerprint->setDescription( 'de', 'bar' );
+		$fingerprint->setAliasGroup( 'nl', array( 'baz' ) );
+
+		return $fingerprint;
+	}
+
+	private function assertFingerprintResultsFromPatch( Fingerprint $expected, Fingerprint $original, EntityDiff $patch ) {
+		$this->assertTrue( $expected->equals( $this->getPatchedFingerprint( $original, $patch ) ) );
+	}
+
+	private function getPatchedFingerprint( Fingerprint $fingerprint, EntityDiff $patch ) {
+		$patched = unserialize( serialize( $fingerprint ) );
+
+		$patcher = new FingerprintPatcher();
+		$patcher->patchFingerprint( $patched, $patch );
+
+		return $patched;
+	}
+
+	public function testLabelDiffOnlyAffectsLabels() {
+		$fingerprint = $this->newSimpleFingerprint();
+
+		$patch = new EntityDiff( array(
+			'label' => new Diff( array(
+				'en' => new DiffOpChange( 'foo', 'bar' ),
+				'de' => new DiffOpAdd( 'baz' ),
+			), true )
+		) );
+
+		$expectedFingerprint = $this->newSimpleFingerprint();
+		$expectedFingerprint->setLabel( 'en', 'bar' );
+		$expectedFingerprint->setLabel( 'de', 'baz' );
+
+		$this->assertFingerprintResultsFromPatch( $expectedFingerprint, $fingerprint, $patch );
+	}
+
+	public function testDescriptionDiffOnlyAffectsDescriptions() {
+		$fingerprint = $this->newSimpleFingerprint();
+
+		$patch = new EntityDiff( array(
+			'description' => new Diff( array(
+				'de' => new DiffOpChange( 'bar', 'foo' ),
+				'en' => new DiffOpAdd( 'baz' ),
+			), true )
+		) );
+
+		$expectedFingerprint = $this->newSimpleFingerprint();
+		$expectedFingerprint->setDescription( 'de', 'foo' );
+		$expectedFingerprint->setDescription( 'en', 'baz' );
+
+		$this->assertFingerprintResultsFromPatch( $expectedFingerprint, $fingerprint, $patch );
+	}
+
+	public function testAliasDiffOnlyAffectsAliases() {
+		$fingerprint = $this->newSimpleFingerprint();
+
+		$patch = new EntityDiff( array(
+			'aliases' => new Diff( array(
+				'de' => new Diff( array( new DiffOpAdd( 'foo' ) ), true ),
+			), true )
+		) );
+
+		$expectedFingerprint = $this->newSimpleFingerprint();
+		$expectedFingerprint->setAliasGroup( 'de', array( 'foo' ) );
+
+		$this->assertFingerprintResultsFromPatch( $expectedFingerprint, $fingerprint, $patch );
+	}
+
+}

--- a/tests/unit/Diff/Internal/SiteLinkListPatcherTest.php
+++ b/tests/unit/Diff/Internal/SiteLinkListPatcherTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Tests\Diff\Internal;
+
+use Diff\DiffOp\Diff\Diff;
+use Diff\DiffOp\DiffOpAdd;
+use Diff\DiffOp\DiffOpChange;
+use Diff\DiffOp\DiffOpRemove;
+use Wikibase\DataModel\Entity\ItemId;
+use Wikibase\DataModel\Services\Diff\Internal\SiteLinkListPatcher;
+use Wikibase\DataModel\SiteLinkList;
+
+/**
+ * @covers Wikibase\DataModel\Services\Diff\Internal\SiteLinkListPatcher
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class SiteLinkListPatcherTest extends \PHPUnit_Framework_TestCase {
+
+	public function testGivenEmptyDiff_linksAreReturnedAsIs() {
+		$links = new SiteLinkList();
+		$links->addNewSiteLink( 'en', 'foo' );
+		$links->addNewSiteLink( 'de', 'bar' );
+
+		$this->assertLinksResultsFromPatch( $links, $links, new Diff() );
+	}
+
+	private function assertLinksResultsFromPatch( SiteLinkList $expected, SiteLinkList $original, Diff $patch ) {
+		$patcher = new SiteLinkListPatcher();
+		$actual = $patcher->getPatchedSiteLinkList( $original, $patch );
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	public function testPatchesMultipleSiteLinks() {
+		$links = new SiteLinkList();
+		$links->addNewSiteLink( 'dewiki', 'bar' );
+		$links->addNewSiteLink( 'nlwiki', 'baz', array( new ItemId( 'Q42' ) ) );
+
+		$patch = new Diff( array(
+			'nlwiki' => new Diff( array(
+				'name'   => new DiffOpChange( 'baz', 'kittens' ),
+				'badges' => new Diff(
+					array(
+						new DiffOpRemove( 'Q42' ),
+					),
+					false
+				)
+			) ),
+			'frwiki' => new Diff( array(
+				'name'   => new DiffOpAdd( 'Berlin' ),
+				'badges' => new Diff(
+					array(
+						new DiffOpAdd( 'Q42' ),
+					),
+					false
+				)
+			) )
+		) );
+
+		$expectedLinks = new SiteLinkList();
+		$expectedLinks->addNewSiteLink( 'dewiki', 'bar' );
+		$expectedLinks->addNewSiteLink( 'nlwiki', 'kittens' );
+		$expectedLinks->addNewSiteLink( 'frwiki', 'Berlin', array( new ItemId( 'Q42' ) ) );
+
+		$this->assertLinksResultsFromPatch( $expectedLinks, $links, $patch );
+	}
+
+	public function testGivenNoBadges_doesNotWarn() {
+		$patcher = new SiteLinkListPatcher();
+		$patch = new Diff( array(
+			'dewiki' => new Diff( array(
+				'name' => new DiffOpAdd( 'Berlin' )
+			), true )
+		) );
+		$siteLinks = $patcher->getPatchedSiteLinkList( new SiteLinkList(), $patch );
+
+		$this->assertCount( 1, $siteLinks );
+	}
+
+}

--- a/tests/unit/Diff/Internal/StatementListDifferTest.php
+++ b/tests/unit/Diff/Internal/StatementListDifferTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Tests\Diff\Internal;
+
+use DataValues\StringValue;
+use Diff\DiffOp\Diff\Diff;
+use Diff\DiffOp\DiffOpAdd;
+use Diff\DiffOp\DiffOpChange;
+use Diff\DiffOp\DiffOpRemove;
+use Wikibase\DataModel\Services\Diff\Internal\StatementListDiffer;
+use Wikibase\DataModel\Snak\PropertyValueSnak;
+use Wikibase\DataModel\Statement\Statement;
+use Wikibase\DataModel\Statement\StatementList;
+
+/**
+ * @covers Wikibase\DataModel\Services\Diff\Internal\StatementListDiffer
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class StatementListDifferTest extends \PHPUnit_Framework_TestCase {
+
+	public function testGivenTwoEmptyLists_diffIsEmpty() {
+		$this->assertResultsInDiff( new StatementList(), new StatementList(), new Diff() );
+	}
+
+	private function assertResultsInDiff( StatementList $fromStatements, StatementList $toStatements, Diff $diff ) {
+		$differ = new StatementListDiffer();
+
+		$actual = $differ->getDiff( $fromStatements, $toStatements );
+
+		$this->assertEquals( $diff, $actual );
+	}
+
+	public function testGivenTwoIdenticalLists_diffIsEmpty() {
+		$statements = new StatementList(
+			$this->getNewStatement( 'zero', 'first' ),
+			$this->getNewStatement( 'one', 'second' )
+		);
+
+		$this->assertResultsInDiff( $statements, $statements, new Diff() );
+	}
+
+	private function getNewStatement( $guid, $hash ) {
+		$statement = new Statement( new PropertyValueSnak( 1, new StringValue( $hash ) ) );
+		$statement->setGuid( $guid );
+		return $statement;
+	}
+
+	public function testGivenToListWithExtraStatement_additionOperationInDiff() {
+		$fromStatements = new StatementList(
+			$this->getNewStatement( 'zero', 'first' ),
+			$this->getNewStatement( 'one', 'second' )
+		);
+
+		$toStatements = new StatementList(
+			$this->getNewStatement( 'zero', 'first' ),
+			$this->getNewStatement( 'two', 'third' ),
+			$this->getNewStatement( 'one', 'second' )
+		);
+
+		$diff = new Diff( array(
+			'two' => new DiffOpAdd( $this->getNewStatement( 'two', 'third' ) ),
+		) );
+
+		$this->assertResultsInDiff( $fromStatements, $toStatements, $diff );
+	}
+
+	public function testGivenToListWithLessStatements_removalOperationsInDiff() {
+		$fromStatements = new StatementList(
+			$this->getNewStatement( 'zero', 'first' ),
+			$this->getNewStatement( 'one', 'second' ),
+			$this->getNewStatement( 'two', 'third' )
+		);
+
+		$toStatements = new StatementList(
+			$this->getNewStatement( 'one', 'second' )
+		);
+
+		$diff = new Diff( array(
+			'zero' => new DiffOpRemove( $this->getNewStatement( 'zero', 'first' ) ),
+			'two' => new DiffOpRemove( $this->getNewStatement( 'two', 'third' ) ),
+		) );
+
+		$this->assertResultsInDiff( $fromStatements, $toStatements, $diff );
+	}
+
+	public function testGivenListWithChangedStatements_changeOperationsInDiff() {
+		$fromStatements = new StatementList(
+			$this->getNewStatement( 'zero', 'first' ),
+			$this->getNewStatement( 'one', 'second' ),
+			$this->getNewStatement( 'two', 'third' )
+		);
+
+		$toStatements = new StatementList(
+			$this->getNewStatement( 'zero', 'FIRST' ),
+			$this->getNewStatement( 'one', 'second' ),
+			$this->getNewStatement( 'two', 'THIRD' )
+		);
+
+		$diff = new Diff( array(
+			'zero' => new DiffOpChange(
+					$this->getNewStatement( 'zero', 'first' ),
+					$this->getNewStatement( 'zero', 'FIRST' )
+				),
+			'two' => new DiffOpChange(
+					$this->getNewStatement( 'two', 'third' ),
+					$this->getNewStatement( 'two', 'THIRD' )
+				),
+		) );
+
+		$this->assertResultsInDiff( $fromStatements, $toStatements, $diff );
+	}
+
+}

--- a/tests/unit/Diff/Internal/StatementListPatcherTest.php
+++ b/tests/unit/Diff/Internal/StatementListPatcherTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Tests\Diff\Internal;
+
+use DataValues\StringValue;
+use Diff\DiffOp\Diff\Diff;
+use Diff\DiffOp\DiffOpAdd;
+use Diff\DiffOp\DiffOpRemove;
+use Wikibase\DataModel\Services\Diff\Internal\StatementListPatcher;
+use Wikibase\DataModel\Snak\PropertyNoValueSnak;
+use Wikibase\DataModel\Snak\PropertySomeValueSnak;
+use Wikibase\DataModel\Snak\PropertyValueSnak;
+use Wikibase\DataModel\Statement\Statement;
+use Wikibase\DataModel\Statement\StatementList;
+
+/**
+ * @covers Wikibase\DataModel\Services\Diff\Internal\StatementListPatcher
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class StatementListPatcherTest extends \PHPUnit_Framework_TestCase {
+
+	public function testGivenEmptyDiff_listIsReturnedAsIs() {
+		$statements = new StatementList();
+
+		$this->assertListResultsFromPatch( $statements, $statements, new Diff() );
+	}
+
+	private function assertListResultsFromPatch( StatementList $expected, StatementList $original, Diff $patch ) {
+		$patcher = new StatementListPatcher();
+		$this->assertEquals( $expected, $patcher->getPatchedStatementList( $original, $patch ) );
+	}
+
+	public function testFoo() {
+		$statement0 = new Statement( new PropertyNoValueSnak( 42 ) );
+		$statement0->setGuid( 's0' );
+
+		$statement1 = new Statement( new PropertySomeValueSnak( 42 ) );
+		$statement1->setGuid( 's1' );
+
+		$statement2 = new Statement( new PropertyValueSnak( 42, new StringValue( 'ohi' ) ) );
+		$statement2->setGuid( 's2' );
+
+		$statement3 = new Statement( new PropertyNoValueSnak( 1 ) );
+		$statement3->setGuid( 's3' );
+
+		$patch = new Diff( array(
+			's0' => new DiffOpRemove( $statement0 ),
+			's2' => new DiffOpAdd( $statement2 ),
+			's3' => new DiffOpAdd( $statement3 )
+		) );
+
+		$source = new StatementList();
+		$source->addStatement( $statement0 );
+		$source->addStatement( $statement1 );
+
+		$expected = new StatementList();
+		$expected->addStatement( $statement1 );
+		$expected->addStatement( $statement2 );
+		$expected->addStatement( $statement3 );
+
+		$this->assertListResultsFromPatch( $expected, $source, $patch );
+	}
+
+}

--- a/tests/unit/Diff/ItemDiffTest.php
+++ b/tests/unit/Diff/ItemDiffTest.php
@@ -1,0 +1,288 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Tests\Diff;
+
+use Diff\DiffOp\Diff\Diff;
+use Diff\DiffOp\DiffOpAdd;
+use Diff\DiffOp\DiffOpChange;
+use Wikibase\DataModel\Entity\Entity;
+use Wikibase\DataModel\Entity\Item;
+use Wikibase\DataModel\Entity\ItemId;
+use Wikibase\DataModel\Services\Diff\ItemDiff;
+use Wikibase\DataModel\SiteLink;
+
+/**
+ * @covers Wikibase\DataModel\Services\Diff\ItemDiff
+ *
+ * @SuppressWarnings(PHPMD)
+ *
+ * @licence GNU GPL v2+
+ * @author Daniel Kinzler
+ * @author Jens Ohlig <jens.ohlig@wikimedia.de>
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ * @author Daniel Kinzler
+ * @author Michał Łazowik
+ */
+class ItemDiffTest extends EntityDiffOldTest {
+
+	public function provideApplyData() {
+		$originalTests = parent::generateApplyData( Item::ENTITY_TYPE );
+		$tests = array();
+
+		/**
+		 * @var Item $a
+		 * @var Item $b
+		 */
+
+		// add link ------------------------------
+		$a = new Item();
+		$a->getSiteLinkList()->addSiteLink(
+			new SiteLink(
+				'enwiki',
+				'Test',
+				array(
+					new ItemId( 'Q42' ),
+					new ItemId( 'Q3' )
+				)
+			)
+		);
+
+		$b = $a->copy();
+		$b->getSiteLinkList()->addSiteLink(
+			new SiteLink(
+				'dewiki',
+				'Test',
+				array(
+					new ItemId( 'Q42' )
+				)
+			)
+		);
+
+		$tests[] = array( $a, $b );
+
+		// add badges
+		$a = new Item();
+		$a->getSiteLinkList()->addSiteLink(
+			new SiteLink(
+				'enwiki',
+				'Test',
+				array(
+					new ItemId( 'Q42' ),
+				)
+			)
+		);
+
+		$b = new Item();
+		$b->getSiteLinkList()->addSiteLink(
+			new SiteLink(
+				'enwiki',
+				'Test',
+				array(
+					new ItemId( 'Q42' ),
+					new ItemId( 'Q3' )
+				)
+			)
+		);
+
+		$tests[] = array( $a, $b );
+
+		// remove badges
+		$a = new Item();
+		$a->getSiteLinkList()->addSiteLink(
+			new SiteLink(
+				'enwiki',
+				'Test',
+				array(
+					new ItemId( 'Q42' ),
+					new ItemId( 'Q3' )
+				)
+			)
+		);
+
+		$b = new Item();
+		$b->getSiteLinkList()->addSiteLink(
+			new SiteLink(
+				'enwiki',
+				'Test',
+				array(
+					new ItemId( 'Q42' )
+				)
+			)
+		);
+
+		// modify badges
+		$a = new Item();
+		$a->getSiteLinkList()->addSiteLink(
+			new SiteLink(
+				'enwiki',
+				'Test',
+				array(
+					new ItemId( 'Q41' ),
+					new ItemId( 'Q3' )
+				)
+			)
+		);
+
+		$b = new Item();
+		$b->getSiteLinkList()->addSiteLink(
+			new SiteLink(
+				'enwiki',
+				'Test',
+				array(
+					new ItemId( 'Q42' ),
+					new ItemId( 'Q3' )
+				)
+			)
+		);
+
+		$tests[] = array( $a, $b );
+
+		// remove link
+		$a = new Item();
+		$a->getSiteLinkList()->addSiteLink(
+			new SiteLink(
+				'enwiki',
+				'Test',
+				array(
+					new ItemId( 'Q42' )
+				)
+			)
+		);
+		$a->getSiteLinkList()->addSiteLink(
+			new SiteLink(
+				'dewiki',
+				'Test',
+				array(
+					new ItemId( 'Q3' )
+				)
+			)
+		);
+
+		$b = $a->copy();
+		$b->getSiteLinkList()->removeLinkWithSiteId( 'enwiki' );
+
+		$tests[] = array( $a, $b );
+
+		// change link
+		$a = new Item();
+		$a->getSiteLinkList()->addSiteLink(
+			new SiteLink(
+				'enwiki',
+				'Test',
+				array(
+					new ItemId( 'Q42' ),
+					new ItemId( 'Q3' )
+				)
+			)
+		);
+
+		$b = new Item();
+		$b->getSiteLinkList()->addSiteLink(
+			new SiteLink(
+				'enwiki',
+				'Test!!!',
+				array(
+					new ItemId( 'Q42' ),
+					new ItemId( 'Q3' )
+				)
+			)
+		);
+
+		$tests[] = array( $a, $b );
+
+		return array_merge( $originalTests, $tests );
+	}
+
+	/**
+	 * @dataProvider provideApplyData
+	 */
+	public function testApply( Entity $a, Entity $b ) {
+		parent::testApply( $a, $b );
+
+		/**
+		 * @var Item $a
+		 * @var Item $b
+		 * @var SiteLink[] $siteLinks
+		 */
+		$siteLinks = array_merge(
+			$a->getSiteLinkList()->toArray(),
+			$b->getSiteLinkList()->toArray()
+		);
+
+		foreach ( $siteLinks as $siteLink ) {
+			$aLink = $a->getSiteLinkList()->getBySiteId( $siteLink->getSiteId() );
+			$bLink = $a->getSiteLinkList()->getBySiteId( $siteLink->getSiteId() );
+
+			$this->assertEquals( $aLink->getPageName(), $bLink->getPageName() );
+
+			$aBadges = $aLink->getBadges();
+			$bBadges = $bLink->getBadges();
+			$this->assertEquals( sort( $aBadges ), sort( $bBadges ) );
+		}
+	}
+
+	public function isEmptyProvider() {
+		$argLists = array();
+
+		$argLists['no ops'] = array( array(), true );
+
+		$argLists['label changed'] = array(
+			array( 'label' => new Diff( array( 'x' => new DiffOpAdd( 'foo' ) ) ) ),
+			false
+		);
+
+		$argLists['empty links diff'] = array(
+			array( 'links' => new Diff( array(), true ) ),
+			true
+		);
+
+		$argLists['non-empty links diff'] = array(
+			array( 'links' => new Diff( array( new DiffOpAdd( 'foo' ) ), true ) ),
+			false
+		);
+
+		return $argLists;
+	}
+
+	/**
+	 * @dataProvider isEmptyProvider
+	 * @param Diff[] $diffOps
+	 * @param bool $isEmpty
+	 */
+	public function testIsEmpty( array $diffOps, $isEmpty ) {
+		$diff = new ItemDiff( $diffOps );
+		$this->assertEquals( $isEmpty, $diff->isEmpty() );
+	}
+
+	/**
+	 * Checks that ItemDiff can handle atomic diffs for substructures.
+	 * This is needed for backwards compatibility with old versions of
+	 * MapDiffer: As of commit ff65735a125e, MapDiffer may generate atomic
+	 * diffs for substructures even in recursive mode (bug 51363).
+	 */
+	public function testAtomicSubstructureWorkaround() {
+		$oldErrorLevel = error_reporting( E_USER_ERROR );
+
+		$atomicListDiff = new DiffOpChange(
+			array( 'a' => 'A', 'b' => 'B' ),
+			array( 'b' => 'B', 'a' => 'A' )
+		);
+
+		$diff = new ItemDiff( array(
+			'aliases' => $atomicListDiff,
+			'label' => $atomicListDiff,
+			'description' => $atomicListDiff,
+			'claim' => $atomicListDiff,
+			'links' => $atomicListDiff,
+		) );
+
+		$this->assertInstanceOf( 'Diff\DiffOp\Diff\Diff', $diff->getAliasesDiff() );
+		$this->assertInstanceOf( 'Diff\DiffOp\Diff\Diff', $diff->getLabelsDiff() );
+		$this->assertInstanceOf( 'Diff\DiffOp\Diff\Diff', $diff->getDescriptionsDiff() );
+		$this->assertInstanceOf( 'Diff\DiffOp\Diff\Diff', $diff->getClaimsDiff() );
+		$this->assertInstanceOf( 'Diff\DiffOp\Diff\Diff', $diff->getSiteLinkDiff() );
+
+		error_reporting( $oldErrorLevel );
+	}
+
+}

--- a/tests/unit/Diff/ItemDifferTest.php
+++ b/tests/unit/Diff/ItemDifferTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Tests\Diff;
+
+use Diff\DiffOp\Diff\Diff;
+use Diff\DiffOp\DiffOpAdd;
+use Diff\DiffOp\DiffOpChange;
+use Diff\DiffOp\DiffOpRemove;
+use Wikibase\DataModel\Entity\Item;
+use Wikibase\DataModel\Services\Diff\ItemDiffer;
+use Wikibase\DataModel\Snak\PropertySomeValueSnak;
+
+/**
+ * @covers Wikibase\DataModel\Services\Diff\ItemDiffer
+ * @covers Wikibase\DataModel\Services\Diff\ItemDiff
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class ItemDifferTest extends \PHPUnit_Framework_TestCase {
+
+	public function testGivenTwoEmptyItems_emptyItemDiffIsReturned() {
+		$differ = new ItemDiffer();
+
+		$diff = $differ->diffEntities( new Item(), new Item() );
+
+		$this->assertInstanceOf( 'Wikibase\DataModel\Services\Diff\ItemDiff', $diff );
+		$this->assertTrue( $diff->isEmpty() );
+	}
+
+	public function testFingerprintIsDiffed() {
+		$firstItem = new Item();
+		$firstItem->getFingerprint()->setLabel( 'en', 'kittens' );
+		$firstItem->getFingerprint()->setAliasGroup( 'en', array( 'cats' ) );
+
+		$secondItem = new Item();
+		$secondItem->getFingerprint()->setLabel( 'en', 'nyan' );
+		$secondItem->getFingerprint()->setDescription( 'en', 'foo bar baz' );
+
+		$differ = new ItemDiffer();
+		$diff = $differ->diffItems( $firstItem, $secondItem );
+
+		$this->assertEquals(
+			new Diff( array( 'en' => new DiffOpChange( 'kittens', 'nyan' ) ) ),
+			$diff->getLabelsDiff()
+		);
+
+		$this->assertEquals(
+			new Diff( array( 'en' => new DiffOpAdd( 'foo bar baz' ) ) ),
+			$diff->getDescriptionsDiff()
+		);
+
+		$this->assertEquals(
+			new Diff( array( 'en' => new Diff( array( new DiffOpRemove( 'cats' ) ) ) ) ),
+			$diff->getAliasesDiff()
+		);
+	}
+
+	public function testClaimsAreDiffed() {
+		$firstItem = new Item();
+
+		$secondItem = new Item();
+		$secondItem->getStatements()->addNewStatement( new PropertySomeValueSnak( 42 ), null, null, 'guid' );
+
+		$differ = new ItemDiffer();
+		$diff = $differ->diffItems( $firstItem, $secondItem );
+
+		$this->assertCount( 1, $diff->getClaimsDiff()->getAdditions() );
+	}
+
+	public function testGivenEmptyItem_constructionDiffIsEmpty() {
+		$differ = new ItemDiffer();
+		$this->assertTrue( $differ->getConstructionDiff( new Item() )->isEmpty() );
+	}
+
+	public function testGivenEmptyItem_destructionDiffIsEmpty() {
+		$differ = new ItemDiffer();
+		$this->assertTrue( $differ->getDestructionDiff( new Item() )->isEmpty() );
+	}
+
+	public function testConstructionDiffContainsAddOperations() {
+		$item = new Item();
+		$item->getFingerprint()->setLabel( 'en', 'foo' );
+		$item->getSiteLinkList()->addNewSiteLink( 'bar', 'baz' );
+
+		$differ = new ItemDiffer();
+		$diff = $differ->getConstructionDiff( $item );
+
+		$this->assertEquals(
+			new Diff( array( 'en' => new DiffOpAdd( 'foo' ) ) ),
+			$diff->getLabelsDiff()
+		);
+
+		$this->assertEquals(
+			new Diff( array( 'bar' => new Diff( array( 'name' => new DiffOpAdd( 'baz' ) ) ) ) ),
+			$diff->getSiteLinkDiff()
+		);
+	}
+
+}

--- a/tests/unit/Diff/ItemPatcherTest.php
+++ b/tests/unit/Diff/ItemPatcherTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Tests\Diff;
+
+use Diff\DiffOp\Diff\Diff;
+use Diff\DiffOp\DiffOpAdd;
+use Diff\DiffOp\DiffOpChange;
+use Wikibase\DataModel\Services\Diff\ItemDiff;
+use Wikibase\DataModel\Services\Diff\ItemPatcher;
+use Wikibase\DataModel\Entity\Item;
+use Wikibase\DataModel\Entity\Property;
+
+/**
+ * @covers Wikibase\DataModel\Services\Diff\ItemPatcher
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class ItemPatcherTest extends \PHPUnit_Framework_TestCase {
+
+	public function testGivenEmptyDiff_itemIsReturnedAsIs() {
+		$item = new Item();
+		$item->getFingerprint()->setLabel( 'en', 'foo' );
+		$item->getSiteLinkList()->addNewSiteLink( 'enwiki', 'bar' );
+
+		$patchedItem = $this->getPatchedItem( $item, new ItemDiff() );
+
+		$this->assertInstanceOf( 'Wikibase\DataModel\Entity\Item', $patchedItem );
+		$this->assertTrue( $item->equals( $patchedItem ) );
+	}
+
+	private function getPatchedItem( Item $item, ItemDiff $patch ) {
+		$patchedItem = $item->copy();
+
+		$patcher = new ItemPatcher();
+		$patcher->patchEntity( $patchedItem, $patch );
+
+		return $patchedItem;
+	}
+
+	public function testCanPatchEntityType() {
+		$patcher = new ItemPatcher();
+		$this->assertTrue( $patcher->canPatchEntityType( 'item' ) );
+		$this->assertFalse( $patcher->canPatchEntityType( 'property' ) );
+		$this->assertFalse( $patcher->canPatchEntityType( '' ) );
+		$this->assertFalse( $patcher->canPatchEntityType( null ) );
+	}
+
+	public function testGivenNonItem_exceptionIsThrown() {
+		$patcher = new ItemPatcher();
+
+		$this->setExpectedException( 'InvalidArgumentException' );
+		$patcher->patchEntity( Property::newFromType( 'kittens' ), new ItemDiff() );
+	}
+
+	public function testPatchesLabels() {
+		$item = new Item();
+		$item->getFingerprint()->setLabel( 'en', 'foo' );
+		$item->getFingerprint()->setLabel( 'de', 'bar' );
+
+		$patch = new ItemDiff( array(
+			'label' => new Diff( array(
+				'en' => new DiffOpChange( 'foo', 'spam' ),
+				'nl' => new DiffOpAdd( 'baz' ),
+			) )
+		) );
+
+		$patchedItem = $this->getPatchedItem( $item, $patch );
+
+		$this->assertSame(
+			array(
+				'en' => 'spam',
+				'de' => 'bar',
+				'nl' => 'baz',
+			),
+			$patchedItem->getFingerprint()->getLabels()->toTextArray()
+		);
+	}
+
+}

--- a/tests/unit/Diff/PropertyDifferTest.php
+++ b/tests/unit/Diff/PropertyDifferTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Tests\Diff;
+
+use Wikibase\DataModel\Services\Diff\PropertyDiffer;
+use Wikibase\DataModel\Entity\Property;
+use Wikibase\DataModel\Snak\PropertySomeValueSnak;
+
+/**
+ * @covers Wikibase\DataModel\Services\Diff\PropertyDiffer
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class PropertyDifferTest extends \PHPUnit_Framework_TestCase {
+
+	public function testGivenPropertyWithOnlyType_constructionDiffIsEmpty() {
+		$differ = new PropertyDiffer();
+		$this->assertTrue( $differ->getConstructionDiff( Property::newFromType( 'string' ) )->isEmpty() );
+	}
+
+	public function testGivenPropertyWithOnlyType_destructionDiffIsEmpty() {
+		$differ = new PropertyDiffer();
+		$this->assertTrue( $differ->getDestructionDiff( Property::newFromType( 'string' ) )->isEmpty() );
+	}
+
+	public function testClaimsAreDiffed() {
+		$firstProperty = Property::newFromType( 'kittens' );
+
+		$secondProperty = Property::newFromType( 'kittens' );
+		$secondProperty->getStatements()->addNewStatement( new PropertySomeValueSnak( 42 ), null, null, 'guid' );
+
+		$differ = new PropertyDiffer();
+		$diff = $differ->diffProperties( $firstProperty, $secondProperty );
+
+		$this->assertCount( 1, $diff->getClaimsDiff()->getAdditions() );
+	}
+
+}

--- a/tests/unit/Diff/PropertyPatcherTest.php
+++ b/tests/unit/Diff/PropertyPatcherTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Tests\Diff;
+
+use Diff\DiffOp\Diff\Diff;
+use Diff\DiffOp\DiffOpAdd;
+use Diff\DiffOp\DiffOpRemove;
+use Wikibase\DataModel\Services\Diff\EntityDiff;
+use Wikibase\DataModel\Services\Diff\PropertyPatcher;
+use Wikibase\DataModel\Entity\Item;
+use Wikibase\DataModel\Entity\Property;
+use Wikibase\DataModel\Snak\PropertyNoValueSnak;
+use Wikibase\DataModel\Statement\Statement;
+
+/**
+ * @covers Wikibase\DataModel\Services\Diff\PropertyPatcher
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class PropertyPatcherTest extends \PHPUnit_Framework_TestCase {
+
+	public function testGivenEmptyDiff_itemIsReturnedAsIs() {
+		$property = Property::newFromType( 'kittens' );
+		$property->getFingerprint()->setLabel( 'en', 'foo' );
+		$property->getStatements()->addNewStatement( new PropertyNoValueSnak( 42 ) );
+
+		$patchedProperty = $this->getPatchedProperty( $property, new EntityDiff() );
+
+		$this->assertInstanceOf( 'Wikibase\DataModel\Entity\Property', $patchedProperty );
+		$this->assertTrue( $property->equals( $patchedProperty ) );
+	}
+
+	private function getPatchedProperty( Property $property, EntityDiff $patch ) {
+		$patchedProperty = $property->copy();
+
+		$patcher = new PropertyPatcher();
+		$patcher->patchEntity( $patchedProperty, $patch );
+
+		return $patchedProperty;
+	}
+
+	public function testCanPatchEntityType() {
+		$patcher = new PropertyPatcher();
+		$this->assertTrue( $patcher->canPatchEntityType( 'property' ) );
+		$this->assertFalse( $patcher->canPatchEntityType( 'item' ) );
+		$this->assertFalse( $patcher->canPatchEntityType( '' ) );
+		$this->assertFalse( $patcher->canPatchEntityType( null ) );
+	}
+
+	public function testGivenNonItem_exceptionIsThrown() {
+		$patcher = new PropertyPatcher();
+
+		$this->setExpectedException( 'InvalidArgumentException' );
+		$patcher->patchEntity( new Item(), new EntityDiff() );
+	}
+
+	public function testStatementsArePatched() {
+		$s1337 = new Statement( new PropertyNoValueSnak( 1337 ) );
+		$s1337->setGuid( 's1337' );
+
+		$s23 = new Statement( new PropertyNoValueSnak( 23 ) );
+		$s23->setGuid( 's23' );
+
+		$s42 = new Statement( new PropertyNoValueSnak( 42 ) );
+		$s42->setGuid( 's42' );
+
+		$patch = new EntityDiff( array(
+				'claim' => new Diff( array(
+					's42' => new DiffOpRemove( $s42 ),
+					's23' => new DiffOpAdd( $s23 ),
+				) )
+			)
+		);
+
+		$property = Property::newFromType( 'kittens' );
+		$property->getStatements()->addStatement( $s1337 );
+		$property->getStatements()->addStatement( $s42 );
+
+		$expectedProperty = Property::newFromType( 'kittens' );
+		$expectedProperty->getStatements()->addStatement( $s1337 );
+		$expectedProperty->getStatements()->addStatement( $s23 );
+
+		$this->assertEquals(
+			$expectedProperty,
+			$this->getPatchedProperty( $property, $patch )
+		);
+	}
+
+}


### PR DESCRIPTION
This is a move with of the DataModel Diff code with minimal changes.
The namespace has been changed from `Wikibase\DataModel\Entity\Diff`
to `Wikibase\DataModel\Services\Diff`. Furthermore, the package
private classes have been put into a `Internal` sub namespace to
make the visibility more distinct.

This change allows for removing the Diff code, and the dependency
on the Diff library, from Wikibase DataModel in its next major
release.

The objects representing the diffs themselves contain some technical
debt. With this move we can solve this when we see fit without
having to create a breaking release for Wikibase DataModel itself.
