### PR TITLE
[WIP] Add validators from wikibase/lib

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,9 @@
 	"require": {
 		"php": ">=5.3.0",
 		"wikibase/data-model": "~3.0",
-		"diff/diff": "~2.0"
+		"diff/diff": "~2.0",
+		"data-values/data-values": "~1.0",
+		"data-values/interfaces": "~0.1"
 	},
 	"require-dev": {
 		"squizlabs/php_codesniffer": "~2.1",

--- a/src/Validation/AlternativeValidator.php
+++ b/src/Validation/AlternativeValidator.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Validation;
+
+use ValueValidators\Error;
+use ValueValidators\Result;
+use ValueValidators\ValueValidator;
+
+/**
+ * An AlternativeValidator uses a list of sub-validators to validate the data.
+ * It does not implement any validation logic directly.
+ * The AlternativeValidator considers the data to be valid if any of the
+ * inner validators accepts the data.
+ *
+ * @license GPL 2+
+ * @author Daniel Kinzler
+ */
+class AlternativeValidator implements ValueValidator {
+
+	/**
+	 * @var ValueValidator[]
+	 */
+	private $validators;
+
+	/**
+	 * @param ValueValidator[] $validators
+	 */
+	public function __construct( array $validators ) {
+		//TODO: make sure they are all instances of ValueValidator
+		$this->validators = $validators;
+	}
+
+	/**
+	 * @see ValueValidator::validate()
+	 *
+	 * @param mixed $value The value to validate
+	 *
+	 * @return Result
+	 */
+	public function validate( $value ) {
+		$result = null;
+
+		foreach ( $this->validators as $validator ) {
+			$subResult = $validator->validate( $value );
+
+			if ( $subResult->isValid() ) {
+				return $subResult;
+			} else {
+				$result = $result ? Result::merge( $result, $subResult ) : $subResult;
+			}
+		}
+
+		if ( !$result ) {
+			$result = Result::newError( array(
+				Error::newError(
+					"No validators",
+					null,
+					'no-validators'
+				)
+			) );
+		}
+
+		return $result;
+	}
+
+	/**
+	 * @see ValueValidator::setOptions()
+	 *
+	 * @param array $options
+	 */
+	public function setOptions( array $options ) {
+		// Do nothing. This method shouldn't even be in the interface.
+	}
+
+}

--- a/src/Validation/CompositeValidator.php
+++ b/src/Validation/CompositeValidator.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Validation;
+
+use ValueValidators\Result;
+use ValueValidators\ValueValidator;
+
+/**
+ * A CompositeValidator uses a list of sub-validators to validate the data.
+ * It does not implement any validation logic directly.
+ *
+ * @license GPL 2+
+ * @author Daniel Kinzler
+ */
+class CompositeValidator implements ValueValidator {
+
+	/**
+	 * @var ValueValidator[]
+	 */
+	private $validators;
+
+	/**
+	 * @var bool
+	 */
+	private $failFast;
+
+	/**
+	 * @param ValueValidator[] $validators
+	 * @param bool $failFast If true, validation will be aborted after the first sub validator fails.
+	 */
+	public function __construct( array $validators, $failFast = true ) {
+		//TODO: make sure they are all instances of ValueValidator
+		$this->validators = $validators;
+		$this->failFast = $failFast;
+	}
+
+	/**
+	 * @see ValueValidator::validate()
+	 *
+	 * @param mixed $value The value to validate
+	 *
+	 * @return Result
+	 */
+	public function validate( $value ) {
+		$result = Result::newSuccess();
+
+		foreach ( $this->validators as $validator ) {
+			$subResult = $validator->validate( $value );
+
+			if ( !$subResult->isValid() ) {
+				if ( $this->failFast ) {
+					return $subResult;
+				} else {
+					$result = Result::merge( $result, $subResult );
+				}
+			}
+		}
+
+		return $result;
+	}
+
+	/**
+	 * @see ValueValidator::setOptions()
+	 *
+	 * @param array $options
+	 */
+	public function setOptions( array $options ) {
+		// Do nothing. This method shouldn't even be in the interface.
+	}
+
+}

--- a/src/Validation/DataFieldValidator.php
+++ b/src/Validation/DataFieldValidator.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Validation;
+
+use InvalidArgumentException;
+use ValueValidators\Error;
+use ValueValidators\Result;
+use ValueValidators\ValueValidator;
+
+/**
+ * The DataFieldValidator class allows the validation of a single field of a complex
+ * DataValues object based on the DataValue's array representation.
+ *
+ * If the respective field is missing or null, the validation will fail with
+ * the code 'missing-field'
+ *
+ * @since 0.4
+ *
+ * @license GPL 2+
+ * @author Daniel Kinzler
+ */
+class DataFieldValidator implements ValueValidator {
+
+	/**
+	 * @var string|int
+	 */
+	private $field;
+
+	/**
+	 * @var ValueValidator
+	 */
+	private $validator;
+
+	/**
+	 * @param string|int     $field     The field on the target DataValue's array representation to check
+	 * @param ValueValidator $validator The validator to apply to the given field
+	 *
+	 * @throws InvalidArgumentException
+	 */
+	public function __construct( $field, ValueValidator $validator ) {
+		if ( !is_string( $field ) && !is_int( $field ) ) {
+			throw new InvalidArgumentException( '$field need to be a string or int' );
+		}
+
+		$this->field = $field;
+		$this->validator = $validator;
+	}
+
+	/**
+	 * @see ValueValidator::validate()
+	 *
+	 * @param array $data The data array to validate
+	 *
+	 * @return Result
+	 * @throws InvalidArgumentException
+	 */
+	public function validate( $data ) {
+		if ( !is_array( $data ) ) {
+			//XXX: or should this just be reported as invalid?
+			throw new InvalidArgumentException( 'DataValue is not represented as an array' );
+		}
+
+		if ( !isset( $data[$this->field] ) ) {
+			return Result::newError( array(
+				Error::newError(
+					'Required field ' . $this->field . ' not set',
+					$this->field,
+					'missing-field',
+					array( $this->field )
+				),
+			) );
+		}
+
+		$fieldValue = $data[$this->field];
+
+		$result = $this->validator->validate( $fieldValue );
+
+		// TODO: include the field name in the error report
+		return $result;
+	}
+
+	/**
+	 * @see ValueValidator::setOptions()
+	 *
+	 * @param array $options
+	 */
+	public function setOptions( array $options ) {
+		// Do nothing. This method shouldn't even be in the interface.
+	}
+
+}

--- a/src/Validation/DataValueValidator.php
+++ b/src/Validation/DataValueValidator.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Validation;
+
+use DataValues\DataValue;
+use InvalidArgumentException;
+use ValueValidators\Result;
+use ValueValidators\ValueValidator;
+
+/**
+ * The DataValueValidator class allows the validation of the plain value
+ * of a simple DataValues object based on the DataValue's array representation.
+ *
+ * @license GPL 2+
+ * @author Daniel Kinzler
+ */
+class DataValueValidator implements ValueValidator {
+
+	/**
+	 * @var ValueValidator
+	 */
+	private $validator;
+
+	/**
+	 * @param ValueValidator $validator The validator to apply to the given field
+	 */
+	public function __construct( ValueValidator $validator ) {
+		$this->validator = $validator;
+	}
+
+	/**
+	 * @see ValueValidator::validate()
+	 *
+	 * @param DataValue $value The value to validate
+	 *
+	 * @throws InvalidArgumentException
+	 * @return Result
+	 */
+	public function validate( $value ) {
+		if ( !( $value instanceof DataValue ) ) {
+			throw new InvalidArgumentException( 'DataValue expected' );
+		}
+
+		$arrayValue = $value->getArrayValue();
+		$result = $this->validator->validate( $arrayValue );
+		return $result;
+	}
+
+	/**
+	 * @see ValueValidator::setOptions()
+	 *
+	 * @param array $options
+	 */
+	public function setOptions( array $options ) {
+		// Do nothing. This method shouldn't even be in the interface.
+	}
+
+}

--- a/src/Validation/EntityExistsValidator.php
+++ b/src/Validation/EntityExistsValidator.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Validation;
+
+use InvalidArgumentException;
+use ValueValidators\Error;
+use ValueValidators\Result;
+use ValueValidators\ValueValidator;
+use Wikibase\DataModel\Entity\EntityId;
+use Wikibase\DataModel\Entity\EntityIdValue;
+use Wikibase\DataModel\Services\Store\EntityLookup;
+
+/**
+ * EntityExistsValidator checks that a given entity exists.
+ *
+ * @license GPL 2+
+ * @author Daniel Kinzler
+ */
+class EntityExistsValidator implements ValueValidator {
+
+	/**
+	 * @var EntityLookup
+	 */
+	private $entityLookup;
+
+	/**
+	 * @var string|null
+	 */
+	private $entityType;
+
+	public function __construct( EntityLookup $entityLookup, $entityType = null ) {
+		if ( !is_string( $entityType ) && !is_null( $entityType ) ) {
+			throw new InvalidArgumentException( '$entityType must be a string or null' );
+		}
+
+		$this->entityLookup = $entityLookup;
+		$this->entityType = $entityType;
+	}
+
+	/**
+	 * @see ValueValidator::validate()
+	 *
+	 * @param EntityIdValue|EntityId $value The ID to validate
+	 *
+	 * @return Result
+	 * @throws InvalidArgumentException
+	 */
+	public function validate( $value ) {
+		if ( $value instanceof EntityIdValue ) {
+			$value = $value->getEntityId();
+		}
+
+		if ( !( $value instanceof EntityId ) ) {
+			throw new InvalidArgumentException( "Expected an EntityId object" );
+		}
+
+		$actualType =  $value->getEntityType();
+
+		$errors = array();
+
+		if ( $this->entityType !== null && $actualType !== $this->entityType ) {
+			$errors[] = Error::newError(
+				"Wrong entity type: " . $actualType,
+				null,
+				'bad-entity-type',
+				array( $actualType )
+			);
+		}
+
+		if ( !$this->entityLookup->hasEntity( $value ) ) {
+			$errors[] = Error::newError(
+				"Entity not found: " . $value,
+				null,
+				'no-such-entity',
+				array( $value )
+			);
+		}
+
+		return empty( $errors ) ? Result::newSuccess() : Result::newError( $errors );
+	}
+
+	/**
+	 * @see ValueValidator::setOptions()
+	 *
+	 * @param array $options
+	 */
+	public function setOptions( array $options ) {
+		// Do nothing. This method shouldn't even be in the interface.
+	}
+
+}

--- a/src/Validation/MembershipValidator.php
+++ b/src/Validation/MembershipValidator.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Validation;
+
+use InvalidArgumentException;
+use ValueValidators\Error;
+use ValueValidators\Result;
+use ValueValidators\ValueValidator;
+
+/**
+ * MembershipValidator checks that a value is in a fixed set of allowed values.
+ *
+ * @license GPL 2+
+ * @author Daniel Kinzler
+ */
+class MembershipValidator implements ValueValidator {
+
+	/**
+	 * @var array
+	 */
+	private $allowed;
+
+	/**
+	 * @var string
+	 */
+	private $errorCode;
+
+	/**
+	 * @var callable|string|null
+	 */
+	private $normalizer;
+
+	/**
+	 * @param array $allowed The allowed values
+	 * @param string $errorCode Code to use in Errors; should indicate what kind of value would have been allowed.
+	 * @param callable|string|null $normalizer An optional function to normalize the value before
+	 *                        comparing it to the list of allowed values, e.g. 'strtolower'.
+	 *
+	 * @throws InvalidArgumentException
+	 */
+	public function __construct( array $allowed, $errorCode = 'not-allowed', $normalizer = null ) {
+		if ( !is_string( $errorCode ) ) {
+			throw new InvalidArgumentException( 'Error code must be a string' );
+		}
+
+		if ( !is_callable( $normalizer ) && $normalizer !== null ) {
+			throw new InvalidArgumentException( 'Normalizer must be callable (or null)' );
+		}
+
+		$this->allowed = $allowed;
+		$this->errorCode = $errorCode;
+		$this->normalizer = $normalizer;
+	}
+
+	/**
+	 * @see ValueValidator::validate
+	 *
+	 * @param string $value The value to validate
+	 *
+	 * @return Result
+	 */
+	public function validate( $value ) {
+		if ( $this->normalizer !== null ) {
+			$value = call_user_func( $this->normalizer, $value );
+		}
+
+		if ( !in_array( $value, $this->allowed, true ) ) {
+			return Result::newError( array(
+				Error::newError(
+					'Not a legal value: ' . $value,
+					null,
+					$this->errorCode,
+					array( $value )
+				)
+			) );
+		}
+
+		return Result::newSuccess();
+	}
+
+	/**
+	 * @see ValueValidator::setOptions
+	 *
+	 * @param array $options
+	 */
+	public function setOptions( array $options ) {
+		// Do nothing. This method shouldn't even be in the interface.
+	}
+
+}

--- a/src/Validation/NotEntityIdValidator.php
+++ b/src/Validation/NotEntityIdValidator.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Validation;
+
+use InvalidArgumentException;
+use ValueValidators\Error;
+use ValueValidators\Result;
+use ValueValidators\ValueValidator;
+use Wikibase\DataModel\Entity\EntityIdParser;
+use Wikibase\DataModel\Entity\EntityIdParsingException;
+
+/**
+ * Validator for checking that a given string is NOT an EntityId.
+ * Useful e.g. for preventing property labels that "look like" property IDs.
+ *
+ * @license GPL 2+
+ * @author Daniel Kinzler
+ */
+class NotEntityIdValidator implements ValueValidator {
+
+	/**
+	 * @var EntityIdParser
+	 */
+	private $idParser;
+
+	/**
+	 * @var string
+	 */
+	private $errorCode;
+
+	/**
+	 * @var string[]|null List of entity types that are to be forbidden by this validator.
+	 */
+	private $forbiddenTypes;
+
+	/**
+	 * @param EntityIdParser $idParser The parser to use for testing whether a string is an entity ID.
+	 * @param string $errorCode The error code to use when this validator fails.
+	 * @param string[]|null $forbiddenTypes A list of entity types who's IDs should be considered
+	 *        invalid values. If null, all valid entity IDs are considered invalid input.
+	 *
+	 * @throws InvalidArgumentException
+	 */
+	public function __construct( EntityIdParser $idParser, $errorCode, $forbiddenTypes = null ) {
+		if ( !is_null( $forbiddenTypes ) && !is_array( $forbiddenTypes ) ) {
+			throw new InvalidArgumentException( '$forbiddenTypes must be an array' );
+		}
+
+		if ( !is_string( $errorCode ) ) {
+			throw new InvalidArgumentException( '$errorCode must be a string' );
+		}
+
+		$this->idParser = $idParser;
+		$this->errorCode = $errorCode;
+		$this->forbiddenTypes = $forbiddenTypes;
+	}
+
+	/**
+	 * @see ValueValidator::validate()
+	 *
+	 * @param string $value The value to validate
+	 *
+	 * @return Result
+	 */
+	public function validate( $value ) {
+		$result = Result::newSuccess();
+
+		try {
+			$entityId = $this->idParser->parse( $value );
+
+			if ( $this->forbiddenTypes === null
+				|| in_array( $entityId->getEntityType(), $this->forbiddenTypes )
+			) {
+				// The label looks like a valid ID - we don't like that!
+				$error = Error::newError(
+					'Looks like an Entity ID: ' . $value,
+					null,
+					$this->errorCode,
+					array( $value )
+				);
+				$result = Result::newError( array( $error ) );
+			}
+		} catch ( EntityIdParsingException $parseException ) {
+			// All fine, the parsing did not work, so there is no entity id :)
+		}
+
+		return $result;
+	}
+
+	/**
+	 * @see ValueValidator::setOptions()
+	 *
+	 * @param array $options
+	 */
+	public function setOptions( array $options ) {
+		// Do nothing. This method shouldn't even be in the interface.
+	}
+
+}

--- a/src/Validation/NumberRangeValidator.php
+++ b/src/Validation/NumberRangeValidator.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Validation;
+
+use ValueValidators\Error;
+use ValueValidators\Result;
+use ValueValidators\ValueValidator;
+
+/**
+ * NumberRangeValidator checks that a numerical value is in a given range.
+ *
+ * @license GPL 2+
+ * @author Daniel Kinzler
+ */
+class NumberRangeValidator implements ValueValidator {
+
+	/**
+	 * @var int|float
+	 */
+	private $min;
+
+	/**
+	 * @var int|float
+	 */
+	private $max;
+
+	/**
+	 * @param int|float  $min
+	 * @param int|float  $max
+	 */
+	public function __construct( $min, $max ) {
+		$this->min = $min;
+		$this->max = $max;
+	}
+
+	/**
+	 * @see ValueValidator::validate()
+	 *
+	 * @param int|float $value The numeric value to validate
+	 *
+	 * @return Result
+	 */
+	public function validate( $value ) {
+		if ( $value < $this->min ) {
+			// XXX: having to provide an array is quite inconvenient
+			return Result::newError( array(
+				Error::newError(
+					'Value out of range, the minimum value is ' . $this->min,
+					null,
+					'too-low',
+					array( $this->min, $value )
+				),
+			) );
+		}
+
+		if ( $value > $this->max ) {
+			return Result::newError( array(
+				Error::newError(
+					'Value out of range, the maximum value is ' . $this->max,
+					null,
+					'too-high',
+					array( $this->max, $value )
+				),
+			) );
+		}
+
+		return Result::newSuccess();
+	}
+
+	/**
+	 * @see ValueValidator::setOptions()
+	 *
+	 * @param array $options
+	 */
+	public function setOptions( array $options ) {
+		// Do nothing. This method shouldn't even be in the interface.
+	}
+
+}

--- a/src/Validation/NumberValidator.php
+++ b/src/Validation/NumberValidator.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Validation;
+
+use ValueValidators\Error;
+use ValueValidators\Result;
+use ValueValidators\ValueValidator;
+
+/**
+ * @license GPL 2+
+ * @author Katie Filbert < aude.wiki@gmail.com >
+ */
+class NumberValidator implements ValueValidator {
+
+	/**
+	 * @see ValueValidator::validate()
+	 *
+	 * @param mixed $value The value to validate
+	 *
+	 * @return Result
+	 */
+	public function validate( $value ) {
+		$isValid = is_int( $value ) || is_float( $value );
+
+		if ( $isValid ) {
+			return Result::newSuccess();
+		}
+
+		return Result::newError( array(
+			Error::newError(
+				'Bad type, expected an integer or float value',
+				null,
+				'bad-type',
+				array( 'number', gettype( $value ) )
+			)
+		) );
+	}
+
+	/**
+	 * @see ValueValidator::setOptions()
+	 *
+	 * @param array $options
+	 */
+	public function setOptions( array $options ) {
+		// Do nothing. This method shouldn't even be in the interface.
+	}
+
+}

--- a/src/Validation/RegexValidator.php
+++ b/src/Validation/RegexValidator.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Validation;
+
+use ValueValidators\Error;
+use ValueValidators\Result;
+use ValueValidators\ValueValidator;
+
+/**
+ * RegexValidator checks a string against a regular expression.
+ *
+ * @license GPL 2+
+ * @author Daniel Kinzler
+ */
+class RegexValidator implements ValueValidator {
+
+	/**
+	 * @var string
+	 */
+	private $expression;
+
+	/**
+	 * @var bool
+	 */
+	private $inverse;
+
+	/**
+	 * @var string
+	 */
+	private $errorCode;
+
+	/**
+	 * @param string  $expression
+	 * @param bool    $inverse
+	 * @param string  $errorCode code to use when this validator fails.
+	 */
+	public function __construct( $expression, $inverse = false, $errorCode = 'malformed-value' ) {
+		//TODO: check type
+		$this->expression = $expression;
+		$this->inverse = $inverse;
+		$this->errorCode = $errorCode;
+	}
+
+	/**
+	 * @see ValueValidator::validate()
+	 *
+	 * @param string $value The value to validate
+	 *
+	 * @return Result
+	 */
+	public function validate( $value ) {
+		$match = preg_match( $this->expression, $value );
+
+		if ( $match === 0 && !$this->inverse ) {
+			// XXX: having to provide an array is quite inconvenient
+			return Result::newError( array(
+				Error::newError(
+					'Pattern match failed: ' . $this->expression,
+					null,
+					$this->errorCode,
+					array( $value )
+				),
+			) );
+		}
+
+		if ( $match === 1 && $this->inverse ) {
+			// XXX: having to provide an array is quite inconvenient
+			return Result::newError( array(
+				Error::newError(
+					'Negative pattern matched: ' . $this->expression,
+					null,
+					$this->errorCode,
+					array( $value )
+				),
+			) );
+		}
+
+		return Result::newSuccess();
+	}
+
+	/**
+	 * @see ValueValidator::setOptions()
+	 *
+	 * @param array $options
+	 */
+	public function setOptions( array $options ) {
+		// Do nothing. This method shouldn't even be in the interface.
+	}
+
+}

--- a/src/Validation/StringLengthValidator.php
+++ b/src/Validation/StringLengthValidator.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Validation;
+
+use ValueValidators\Error;
+use ValueValidators\Result;
+use ValueValidators\ValueValidator;
+
+/**
+ * StringLengthValidator checks a string's length
+ *
+ * @license GPL 2+
+ * @author Daniel Kinzler
+ */
+class StringLengthValidator implements ValueValidator {
+
+	/**
+	 * @var int
+	 */
+	private $minLength;
+
+	/**
+	 * @var int
+	 */
+	private $maxLength;
+
+	/**
+	 * @var callable
+	 */
+	private $measure;
+
+	/**
+	 * @param int             $minLength
+	 * @param int             $maxLength
+	 * @param callable|string $measure The function to use to measure the string's length.
+	 *                        Use 'strlen' for byte length and 'mb_strlen' for character length.
+	 *                        A callable can be used to provide an alternative measure.
+	 */
+	public function __construct( $minLength, $maxLength, $measure = 'strlen' ) {
+		//TODO: check type
+		$this->minLength = $minLength;
+		$this->maxLength = $maxLength;
+
+		//TODO: check callable
+		$this->measure = $measure;
+	}
+
+	/**
+	 * @see ValueValidator::validate()
+	 *
+	 * @param string $value The value to validate
+	 *
+	 * @return Result
+	 */
+	public function validate( $value ) {
+		$length = call_user_func( $this->measure, $value );
+
+		if ( $length < $this->minLength ) {
+			// XXX: having to provide an array is quite inconvenient
+			return Result::newError( array(
+				Error::newError(
+					'Too short, minimum length is ' . $this->minLength,
+					null,
+					'too-short',
+					array( $this->minLength, $value )
+				),
+			) );
+		}
+
+		if ( $length > $this->maxLength ) {
+			return Result::newError( array(
+				Error::newError(
+					'Too long, maximum length is ' . $this->maxLength,
+					null,
+					'too-long',
+					array( $this->maxLength, $this->truncateValue( $value ) )
+				),
+			) );
+		}
+
+		return Result::newSuccess();
+	}
+
+	/**
+	 * @see ValueValidator::setOptions()
+	 *
+	 * @param array $options
+	 */
+	public function setOptions( array $options ) {
+		// Do nothing. This method shouldn't even be in the interface.
+	}
+
+	/**
+	 * Truncates the value to the max length, if the value is larger than some maximum length.
+	 * To be used only for informative purposes (such as error messages) when the value is
+	 * already known to be longer than the maximum specified in the constructor.
+	 *
+	 * @param string $value
+	 * @param int $truncateAt The length after which to truncate.
+	 * Note that this is unrelated to the max length we validate against.
+	 *
+	 * @return string
+	 */
+	private function truncateValue( $value, $truncateAt = 32 ) {
+		$length = call_user_func( $this->measure, $value );
+
+		if ( $length > $truncateAt ) {
+			$value = substr( $value, 0, max( 1, $truncateAt - 3 ) ) . '...';
+		}
+
+		return $value;
+	}
+
+}

--- a/src/Validation/TypeValidator.php
+++ b/src/Validation/TypeValidator.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Validation;
+
+use ValueValidators\Error;
+use ValueValidators\Result;
+use ValueValidators\ValueValidator;
+
+/**
+ * TypeValidator checks a value's data type.
+ *
+ * @license GPL 2+
+ * @author Daniel Kinzler
+ */
+class TypeValidator implements ValueValidator {
+
+	/**
+	 * @var string
+	 */
+	private $type;
+
+	/**
+	 * Constructs a TypeValidator that checks for the given type.
+	 *
+	 * @param string $type A PHP type name or a class name.
+	 */
+	public function __construct( $type ) {
+		$this->type = $type;
+	}
+
+	/**
+	 * @see ValueValidator::validate()
+	 *
+	 * @param mixed $value The value to validate
+	 *
+	 * @return Result
+	 */
+	public function validate( $value ) {
+		$type = gettype( $value );
+
+		if ( $type === $this->type ) {
+			return Result::newSuccess();
+		}
+
+		if ( is_object( $value ) ) {
+			$type = get_class( $value );
+
+			if ( is_a( $value, $this->type ) ) {
+				return Result::newSuccess();
+			}
+		}
+
+		return Result::newError( array(
+			Error::newError( 'Bad type, expected ' . $this->type, null, 'bad-type', array( $this->type, $type ) )
+		) );
+	}
+
+	/**
+	 * @see ValueValidator::setOptions()
+	 *
+	 * @param array $options
+	 */
+	public function setOptions( array $options ) {
+		// Do nothing. This method shouldn't even be in the interface.
+	}
+
+}

--- a/src/Validation/UrlSchemeValidators.php
+++ b/src/Validation/UrlSchemeValidators.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Validation;
+
+use ValueValidators\ValueValidator;
+
+/**
+ * UrlSchemeValidators is a collection of validators for some commonly used URL schemes.
+ * This is intended for conveniently supplying a map of validators to UrlValidator.
+ *
+ * @license GPL 2+
+ * @author Daniel Kinzler
+ * @author Thiemo Mättig
+ */
+class UrlSchemeValidators {
+
+	/**
+	 * @var string
+	 */
+	private $linkUrlClass;
+
+	/**
+	 * @param string $linkUrlClass
+	 */
+	public function __construct( $linkUrlClass ) {
+		$this->linkUrlClass = $linkUrlClass;
+	}
+
+	/**
+	 * Returns a validator for the given URL scheme, or null if
+	 * no validator is defined for that scheme.
+	 *
+	 * @todo 'bitcoin', 'geo', 'magnet', 'news', 'sip', 'sips', 'sms', 'tel', 'urn', 'xmpp'.
+	 * @todo protocol relative '//'.
+	 *
+	 * @param string $scheme e.g. 'http'.
+	 *
+	 * @return ValueValidator|null
+	 */
+	public function getValidator( $scheme ) {
+		switch ( $scheme ) {
+			case 'ftp':
+			case 'ftps':
+			case 'git':
+			case 'gopher':
+			case 'http':
+			case 'https':
+			case 'irc':
+			case 'ircs':
+			case 'mms':
+			case 'nntp':
+			case 'redis':
+			case 'sftp':
+			case 'ssh':
+			case 'svn':
+			case 'telnet':
+			case 'worldwind':
+				$regex = '!^' . preg_quote( $scheme, '!' ) . '://(' . $this->linkUrlClass . ')+$!i';
+				break;
+
+			case 'mailto':
+				$regex = '!^mailto:(' . $this->linkUrlClass . ')+@(' . $this->linkUrlClass . ')+$!i';
+				break;
+
+			case '*':
+			case 'any':
+				$regex = '!^([a-z][a-z\d+.-]*):(' . $this->linkUrlClass . ')+$!i';
+				break;
+
+			default:
+				return null;
+		}
+
+		return new RegexValidator( $regex, false, 'bad-url' );
+	}
+
+	/**
+	 * Given a list of schemes, this function returns a mapping for each supported
+	 * scheme to a corresponding ValueValidator. If the schema isn't supported,
+	 * no mapping is created for it.
+	 *
+	 * @param string[] $schemes a list of scheme names, e.g. 'http'.
+	 *
+	 * @return ValueValidator[] a map of scheme names to ValueValidator objects.
+	 */
+	public function getValidators( array $schemes ) {
+		$validators = array();
+
+		foreach ( $schemes as $scheme ) {
+			$validator = $this->getValidator( $scheme );
+
+			if ( $validator !== null ) {
+				$validators[$scheme] = $validator;
+			}
+		}
+
+		return $validators;
+	}
+
+}

--- a/src/Validation/UrlValidator.php
+++ b/src/Validation/UrlValidator.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Validation;
+
+use InvalidArgumentException;
+use ValueValidators\Error;
+use ValueValidators\Result;
+use ValueValidators\ValueValidator;
+
+/**
+ * UrlValidator checks URLs based on sub-validators for each scheme.
+ *
+ * @license GPL 2+
+ * @author Daniel Kinzler
+ */
+class UrlValidator implements ValueValidator {
+
+	/**
+	 * @var ValueValidator[]
+	 */
+	private $validators;
+
+	/**
+	 * Constructs a UrlValidator that checks the given URL schemes.
+	 *
+	 * @param ValueValidator[] $validators a map of scheme names (e.g. 'html') to ValueValidators.
+	 *        The special scheme name "*" can be used to specify a validator for
+	 *        other schemes. You may want to use UrlSchemaValidators to create the
+	 *        respective validators conveniently.
+	 *
+	 * @throws InvalidArgumentException
+	 */
+	public function __construct( array $validators ) {
+		foreach ( $validators as $scheme => $validator ) {
+			if ( !is_string( $scheme ) ) {
+				throw new InvalidArgumentException( 'The keys in $validators must be strings (scheme names).' );
+			}
+
+			if ( !( $validator instanceof ValueValidator ) ) {
+				throw new InvalidArgumentException( 'The values in $validators must be instances of ValueValidator.' );
+			}
+		}
+
+		$this->validators = $validators;
+	}
+
+	/**
+	 * @see ValueValidator::validate()
+	 *
+	 * @param string $url
+	 *
+	 * @throws InvalidArgumentException
+	 * @return Result
+	 */
+	public function validate( $url ) {
+		if ( !is_string( $url ) ) {
+			throw new InvalidArgumentException( '$url must be a string.' );
+		}
+
+		// See RFC 3986, section-3.1.
+		if ( !preg_match( '/^([-+.a-z\d]+):/i', $url, $matches ) ) {
+			return Result::newError( array(
+				Error::newError( 'Malformed URL, can\'t find scheme name.', null, 'bad-url', array( $url ) )
+			) );
+		}
+
+		// Should we also check for and fail on whitespace in $value?
+
+		$scheme = strtolower( $matches[1] );
+
+		if ( isset( $this->validators[$scheme] ) ) {
+			$validator = $this->validators[$scheme];
+		} elseif ( isset( $this->validators['*'] ) ) {
+			$validator = $this->validators['*'];
+		} else {
+			return Result::newError( array(
+				Error::newError( 'Unsupported URL scheme', null, 'bad-url-scheme', array( $scheme ) )
+			) );
+		}
+
+		return $validator->validate( $url );
+	}
+
+	/**
+	 * @see ValueValidator::setOptions()
+	 *
+	 * @param array $options
+	 */
+	public function setOptions( array $options ) {
+		// Do nothing. This method shouldn't even be in the interface.
+	}
+
+}


### PR DESCRIPTION
This introduces dependencies on data-values components. If we don't
want them in here we have to introduce even another component.
EntityLookup should be moved here in another patch.
Parser::EXT_LINK_URL_CLASS got replaced with a private property
and should be set in the constructor to the constant defined in Parser.

**WIP**: Tests missing; do we want/need to somehow import the git history of the moved code?
