### PR TITLE
Move over EntityRetrievingTermLookup

### DIFF
--- a/src/Lookup/EntityRetrievingTermLookup.php
+++ b/src/Lookup/EntityRetrievingTermLookup.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Lookup;
+
+use OutOfBoundsException;
+use Wikibase\DataModel\Term\Fingerprint;
+use Wikibase\DataModel\Entity\EntityId;
+use Wikibase\DataModel\Term\FingerprintProvider;
+
+/**
+ * @since 1.1
+ *
+ * @licence GNU GPL v2+
+ * @author Katie Filbert < aude.wiki@gmail.com >
+ */
+class EntityRetrievingTermLookup implements TermLookup {
+
+	/**
+	 * @var EntityLookup
+	 */
+	private $entityLookup;
+
+	/**
+	 * @var Fingerprint[]
+	 */
+	private $fingerprints;
+
+	/**
+	 * @param EntityLookup $entityLookup
+	 */
+	public function __construct( EntityLookup $entityLookup ) {
+		$this->entityLookup = $entityLookup;
+	}
+
+	/**
+	 * @see TermLookup::getLabel()
+	 *
+	 * @param EntityId $entityId
+	 * @param string $languageCode
+	 *
+	 * @return string
+	 */
+	public function getLabel( EntityId $entityId, $languageCode ) {
+		$labels = $this->getFingerprint( $entityId )->getLabels();
+		return $labels->getByLanguage( $languageCode )->getText();
+	}
+
+	/**
+	 * @see TermLookup::getLabels()
+	 *
+	 * @param EntityId $entityId
+	 * @param string[] $languages
+	 *
+	 * @throws OutOfBoundsException if the entity does not exist
+	 * @return string[]
+	 */
+	public function getLabels( EntityId $entityId, array $languages ) {
+		$labels = $this->getFingerprint( $entityId )->getLabels()->toTextArray();
+
+		return array_intersect_key( $labels, array_flip( $languages ) );
+	}
+
+	/**
+	 * @see TermLookup::getDescription()
+	 *
+	 * @param EntityId $entityId
+	 * @param string $languageCode
+	 *
+	 * @return string
+	 */
+	public function getDescription( EntityId $entityId, $languageCode ) {
+		$descriptions = $this->getFingerprint( $entityId )->getDescriptions();
+		return $descriptions->getByLanguage( $languageCode )->getText();
+	}
+
+	/**
+	 * @see TermLookup::getDescriptions()
+	 *
+	 * @param EntityId $entityId
+	 * @param string[] $languages
+	 *
+	 * @throws OutOfBoundsException if the entity does not exist
+	 * @return string[]
+	 */
+	public function getDescriptions( EntityId $entityId, array $languages ) {
+		$descriptions = $this->getFingerprint( $entityId )->getDescriptions()->toTextArray();
+
+		return array_intersect_key( $descriptions, array_flip( $languages ) );
+	}
+
+	/**
+	 * @param EntityId $entityId
+	 *
+	 * @return Fingerprint
+	 */
+	private function getFingerprint( EntityId $entityId ) {
+		$idSerialization = $entityId->getSerialization();
+
+		if ( !isset( $this->fingerprints[$idSerialization] ) ) {
+			$this->fingerprints[$idSerialization] = $this->fetchFingerprint( $entityId );
+		}
+
+		return $this->fingerprints[$idSerialization];
+	}
+
+	/**
+	 * @param EntityId $entityId
+	 *
+	 * @throws OutOfBoundsException
+	 * @return Fingerprint
+	 */
+	private function fetchFingerprint( EntityId $entityId ) {
+		try {
+			$entity = $this->entityLookup->getEntity( $entityId );
+		} catch ( \Exception $ex ) {
+			// TODO: remove this after addressing violations of EntityLookup::getEntity's contract
+			$entity = null;
+		}
+
+		if ( $entity === null ) {
+			throw new OutOfBoundsException( "An Entity with the id $entityId could not be loaded" );
+		}
+
+		return $entity instanceof FingerprintProvider ? $entity->getFingerprint() : new Fingerprint();
+	}
+
+}

--- a/tests/fixtures/InMemoryEntityLookup.php
+++ b/tests/fixtures/InMemoryEntityLookup.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Fixtures;
+
+use Wikibase\DataModel\Entity\EntityDocument;
+use Wikibase\DataModel\Entity\EntityId;
+use Wikibase\DataModel\Services\Lookup\EntityLookup;
+
+class InMemoryEntityLookup implements EntityLookup {
+
+	private $entities = array();
+
+	public function addEntity( EntityDocument $entity ) {
+		if ( $entity->getId() === null ) {
+			throw new \InvalidArgumentException( 'The entity needs to have an ID' );
+		}
+
+		$this->entities[$entity->getId()->getSerialization()] = $entity;
+	}
+
+	public function getEntity( EntityId $entityId ) {
+		if ( array_key_exists( $entityId->getSerialization(), $this->entities ) ) {
+			return $this->entities[$entityId->getSerialization()];
+		}
+
+		return null;
+	}
+
+	public function hasEntity( EntityId $entityId ) {
+		return array_key_exists( $entityId->getSerialization(), $this->entities );
+	}
+
+}


### PR DESCRIPTION
This class was copied from Wikibase Lib.

Some alternations where made. fetchFingerprint now catches Exception
rather than two more specific ones and has a TODO (#28) there as it should
not be catching an exception as per EntityLookup interface contract.

The test was also modified to use a new trivial EntityLookup implementation,
rather than the 900 line and rather complex MockRepository class.
