### PR TITLE
Move over LanguageLabelDescriptionLookup from Wikibase Lib

### DIFF
--- a/src/Lookup/LanguageLabelDescriptionLookup.php
+++ b/src/Lookup/LanguageLabelDescriptionLookup.php
@@ -37,7 +37,7 @@ class LanguageLabelDescriptionLookup implements LabelDescriptionLookup {
 	/**
 	 * @param EntityId $entityId
 	 *
-	 * @throws OutOfBoundsException
+	 * @throws OutOfBoundsException if no such label or entity could be found
 	 * @return Term
 	 */
 	public function getLabel( EntityId $entityId ) {

--- a/src/Lookup/LanguageLabelDescriptionLookup.php
+++ b/src/Lookup/LanguageLabelDescriptionLookup.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Lookup;
+
+use OutOfBoundsException;
+use Wikibase\DataModel\Entity\EntityId;
+use Wikibase\DataModel\Term\Term;
+
+/**
+ * @since 1.1
+ *
+ * @licence GNU GPL v2+
+ * @author Katie Filbert < aude.wiki@gmail.com >
+ * @author Marius Hoch < hoo@online.de >
+ */
+class LanguageLabelDescriptionLookup implements LabelDescriptionLookup {
+
+	/**
+	 * @var TermLookup
+	 */
+	private $termLookup;
+
+	/**
+	 * @var string
+	 */
+	private $languageCode;
+
+	/**
+	 * @param TermLookup $termLookup
+	 * @param string $languageCode
+	 */
+	public function __construct( TermLookup $termLookup, $languageCode ) {
+		$this->termLookup = $termLookup;
+		$this->languageCode = $languageCode;
+	}
+
+	/**
+	 * @param EntityId $entityId
+	 *
+	 * @throws OutOfBoundsException
+	 * @return Term
+	 */
+	public function getLabel( EntityId $entityId ) {
+		$text = $this->termLookup->getLabel( $entityId, $this->languageCode );
+		return new Term( $this->languageCode, $text );
+	}
+
+	/**
+	 * @param EntityId $entityId
+	 *
+	 * @throws OutOfBoundsException if no such description or entity could be found
+	 * @return Term
+	 */
+	public function getDescription( EntityId $entityId ) {
+		$text = $this->termLookup->getDescription( $entityId, $this->languageCode );
+		return new Term( $this->languageCode, $text );
+	}
+
+}

--- a/tests/unit/Lookup/LanguageLabelDescriptionLookupTest.php
+++ b/tests/unit/Lookup/LanguageLabelDescriptionLookupTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Tests\Lookup;
+
+use Wikibase\DataModel\Entity\ItemId;
+use Wikibase\DataModel\Services\Lookup\LanguageLabelDescriptionLookup;
+use Wikibase\DataModel\Term\Term;
+
+/**
+ * @covers Wikibase\DataModel\Services\Lookup\LanguageLabelDescriptionLookup
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class LanguageLabelDescriptionLookupTest extends \PHPUnit_Framework_TestCase {
+
+	public function testGetLabel() {
+		$termLookup = $this->getMock( 'Wikibase\DataModel\Services\Lookup\TermLookup' );
+
+		$termLookup->expects( $this->once() )
+			->method( 'getLabel' )
+			->with( $this->equalTo( new ItemId( 'Q42' ) ), $this->equalTo( 'language_code' ) )
+			->willReturn( 'term_text' );
+
+		$lookup = new LanguageLabelDescriptionLookup( $termLookup, 'language_code' );
+
+		$this->assertEquals(
+			new Term( 'language_code', 'term_text' ),
+			$lookup->getLabel( new ItemId( 'Q42' ) )
+		);
+	}
+
+	public function testGetDescription() {
+		$termLookup = $this->getMock( 'Wikibase\DataModel\Services\Lookup\TermLookup' );
+
+		$termLookup->expects( $this->once() )
+			->method( 'getDescription' )
+			->with( $this->equalTo( new ItemId( 'Q42' ) ), $this->equalTo( 'language_code' ) )
+			->willReturn( 'term_text' );
+
+		$lookup = new LanguageLabelDescriptionLookup( $termLookup, 'language_code' );
+
+		$this->assertEquals(
+			new Term( 'language_code', 'term_text' ),
+			$lookup->getDescription( new ItemId( 'Q42' ) )
+		);
+	}
+
+}


### PR DESCRIPTION
The LanguageLabelDescriptionLookup class is an exact copy (NS changed).

I threw the old test away and wrote a new one from scratch, as the old
one was testing TermLookup more than LanguageLabelDescriptionLookup and
also bound to some production code that LanguageLabelDescriptionLookup
itself does not depend on.
