### PR TITLE
Improve PHPUnit compatibility

### DIFF
--- a/tests/unit/Lookup/LanguageLabelDescriptionLookupTest.php
+++ b/tests/unit/Lookup/LanguageLabelDescriptionLookupTest.php
@@ -20,7 +20,7 @@ class LanguageLabelDescriptionLookupTest extends \PHPUnit_Framework_TestCase {
 		$termLookup->expects( $this->once() )
 			->method( 'getLabel' )
 			->with( $this->equalTo( new ItemId( 'Q42' ) ), $this->equalTo( 'language_code' ) )
-			->willReturn( 'term_text' );
+			->will( $this->returnValue( 'term_text' ) );
 
 		$lookup = new LanguageLabelDescriptionLookup( $termLookup, 'language_code' );
 
@@ -36,7 +36,7 @@ class LanguageLabelDescriptionLookupTest extends \PHPUnit_Framework_TestCase {
 		$termLookup->expects( $this->once() )
 			->method( 'getDescription' )
 			->with( $this->equalTo( new ItemId( 'Q42' ) ), $this->equalTo( 'language_code' ) )
-			->willReturn( 'term_text' );
+			->will( $this->returnValue( 'term_text' ) );
 
 		$lookup = new LanguageLabelDescriptionLookup( $termLookup, 'language_code' );
 


### PR DESCRIPTION
I would love to use these methods, but they do not exist in PHPUnit version we still use. The shorter code is not worth the reduced compatibility. That's why no other test in our whole code base uses these new methods. This are the only 2 code lines.
