### PR TITLE
Remove --coverage-php option

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
 	"scripts": {
 		"test": [
 			"composer validate --no-interaction",
-			"phpunit --coverage-php /dev/null"
+			"phpunit"
 		],
 		"cs": [
 			"composer phpcs",


### PR DESCRIPTION
The difference (on my machine) is ~190 ms versus ~1.5 seconds. That's sooo much slower that it's not worth the benefit, in my opinion. It would be cool to have this coverage test run once a day or something like this, but it should not slow down CI.
