### PR TITLE
Add EntityNotFoundException & use in EntityLookup

### DIFF
--- a/src/Lookup/EntityLookup.php
+++ b/src/Lookup/EntityLookup.php
@@ -17,8 +17,7 @@ use Wikibase\DataModel\Entity\EntityId;
 interface EntityLookup {
 
 	/**
-	 * Returns the entity with the provided id or null if there is no such
-	 * entity.
+	 * Returns the entity with the provided id.
 	 *
 	 * @note Implementations of this method may or may not resolve redirects.
 	 * Code that needs control over redirect resolution should use an
@@ -28,7 +27,8 @@ interface EntityLookup {
 	 *
 	 * @param EntityId $entityId
 	 *
-	 * @return EntityDocument|null
+	 * @return EntityDocument
+	 * @throws EntityNotFoundException
 	 */
 	public function getEntity( EntityId $entityId );
 

--- a/src/Lookup/EntityNotFoundException.php
+++ b/src/Lookup/EntityNotFoundException.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Lookup;
+
+use Wikibase\DataModel\Entity\EntityId;
+
+/**
+ * @since 1.2
+ *
+ * @licence GNU GPL v2+
+ * @author Adam Shorland
+ */
+class EntityNotFoundException extends \RuntimeException {
+
+	private $entityId;
+
+	public function __construct( EntityId $entityId, $message = null, \Exception $previous = null ) {
+		$this->entityId = $entityId;
+
+		parent::__construct(
+			$message ?: 'Entity not found: ' . $entityId,
+			0,
+			$previous
+		);
+	}
+
+	/**
+	 * @return EntityId
+	 */
+	public function getEntityId() {
+		return $this->entityId;
+	}
+
+}

--- a/src/Lookup/ItemNotFoundException.php
+++ b/src/Lookup/ItemNotFoundException.php
@@ -10,16 +10,12 @@ use Wikibase\DataModel\Entity\ItemId;
  * @licence GNU GPL v2+
  * @author Thomas Pellissier Tanon
  */
-class ItemNotFoundException extends \RuntimeException {
-
-	private $itemId;
+class ItemNotFoundException extends EntityNotFoundException {
 
 	public function __construct( ItemId $itemId, $message = null, \Exception $previous = null ) {
-		$this->itemId = $itemId;
-
 		parent::__construct(
+			$itemId,
 			$message ?: 'Item not found: ' . $itemId,
-			0,
 			$previous
 		);
 	}
@@ -28,7 +24,7 @@ class ItemNotFoundException extends \RuntimeException {
 	 * @return ItemId
 	 */
 	public function getItemId() {
-		return $this->itemId;
+		return $this->getEntityId();
 	}
 
 }

--- a/src/Lookup/PropertyNotFoundException.php
+++ b/src/Lookup/PropertyNotFoundException.php
@@ -10,25 +10,21 @@ use Wikibase\DataModel\Entity\PropertyId;
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-class PropertyNotFoundException extends \RuntimeException {
-
-	private $propertyId;
+class PropertyNotFoundException extends EntityNotFoundException {
 
 	public function __construct( PropertyId $propertyId, $message = null, \Exception $previous = null ) {
-		$this->propertyId = $propertyId;
-
 		if ( $message === null ) {
 			$message = "Property not found: " . $propertyId;
 		}
 
-		parent::__construct( $message, 0, $previous );
+		parent::__construct( $propertyId, $message, $previous );
 	}
 
 	/**
 	 * @return PropertyId
 	 */
 	public function getPropertyId() {
-		return $this->propertyId;
+		return $this->getEntityId();
 	}
 
 }

--- a/src/Lookup/RedirectResolvingEntityLookup.php
+++ b/src/Lookup/RedirectResolvingEntityLookup.php
@@ -44,7 +44,8 @@ class RedirectResolvingEntityLookup implements EntityLookup {
 	 *
 	 * @param EntityId $entityId
 	 *
-	 * @return EntityDocument|null
+	 * @return EntityDocument
+	 * @throws EntityNotFoundException
 	 */
 	public function getEntity( EntityId $entityId ) {
 		return $this->lookup->getEntity( $entityId );

--- a/tests/unit/Lookup/EntityNotFoundExceptionTest.php
+++ b/tests/unit/Lookup/EntityNotFoundExceptionTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Tests\Lookup;
+
+use Wikibase\DataModel\Entity\PropertyId;
+use Wikibase\DataModel\Services\Lookup\EntityNotFoundException;
+
+/**
+ * @covers Wikibase\DataModel\Services\Lookup\EntityNotFoundException
+ *
+ * @licence GNU GPL v2+
+ * @author Adam Shorland
+ */
+class EntityNotFoundExceptionTest extends \PHPUnit_Framework_TestCase {
+
+	public function testConstructorWithJustATable() {
+		$propertyId = new PropertyId( 'P42' );
+		$exception = new EntityNotFoundException( $propertyId );
+
+		$this->assertEquals( $propertyId, $exception->getEntityId() );
+	}
+
+}


### PR DESCRIPTION
This breaks the last contract of this interface.

getEntity should no longer return null but should
throw an exception instead.
