### PR TITLE
Revert to use non-deprecated Item::copy and Property::copy

### DIFF
--- a/tests/unit/Diff/EntityPatcherTest.php
+++ b/tests/unit/Diff/EntityPatcherTest.php
@@ -24,7 +24,7 @@ class EntityPatcherTest extends \PHPUnit_Framework_TestCase {
 	public function testGivenEmptyDiffItemRemainsUnchanged( Item $item ) {
 		$patcher = new EntityPatcher();
 
-		$patchedEntity = unserialize( serialize( $item ) );
+		$patchedEntity = $item->copy();
 		$patcher->patchEntity( $patchedEntity, new ItemDiff() );
 
 		$this->assertEquals( $item, $patchedEntity );

--- a/tests/unit/Diff/ItemDiffTest.php
+++ b/tests/unit/Diff/ItemDiffTest.php
@@ -47,7 +47,7 @@ class ItemDiffTest extends EntityDiffOldTest {
 			)
 		);
 
-		$b = unserialize( serialize( $a ) );
+		$b = $a->copy();
 		$b->getSiteLinkList()->addSiteLink(
 			new SiteLink(
 				'dewiki',
@@ -158,7 +158,7 @@ class ItemDiffTest extends EntityDiffOldTest {
 			)
 		);
 
-		$b = unserialize( serialize( $a ) );
+		$b = $a->copy();
 		$b->getSiteLinkList()->removeLinkWithSiteId( 'enwiki' );
 
 		$tests[] = array( $a, $b );

--- a/tests/unit/Diff/ItemPatcherTest.php
+++ b/tests/unit/Diff/ItemPatcherTest.php
@@ -30,7 +30,7 @@ class ItemPatcherTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	private function getPatchedItem( Item $item, ItemDiff $patch ) {
-		$patchedItem = unserialize( serialize( $item ) );
+		$patchedItem = $item->copy();
 
 		$patcher = new ItemPatcher();
 		$patcher->patchEntity( $patchedItem, $patch );

--- a/tests/unit/Diff/PropertyPatcherTest.php
+++ b/tests/unit/Diff/PropertyPatcherTest.php
@@ -32,7 +32,7 @@ class PropertyPatcherTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	private function getPatchedProperty( Property $property, EntityDiff $patch ) {
-		$patchedProperty = unserialize( serialize( $property ) );
+		$patchedProperty = $property->copy();
 
 		$patcher = new PropertyPatcher();
 		$patcher->patchEntity( $patchedProperty, $patch );


### PR DESCRIPTION
This reverts parts of https://gerrit.wikimedia.org/r/#/c/222978/. See https://github.com/wmde/WikibaseDataModel/pull/531 for arguments. In short: Yes, `Entity` is deprecated and `Entity::copy` should not be called. But `Item::copy` and `Property::copy` are **not** deprecated.
