### PR TITLE
Add missing Exceptions & Tests

### DIFF
--- a/src/Lookup/ItemLookupException.php
+++ b/src/Lookup/ItemLookupException.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Lookup;
+
+use Wikibase\DataModel\Entity\ItemId;
+
+/**
+ * @since 2.0
+ *
+ * @licence GNU GPL v2+
+ * @author Adam Shorland
+ */
+class ItemLookupException extends EntityLookupException {
+
+	public function __construct( ItemId $itemId, $message = null, \Exception $previous = null ) {
+		parent::__construct(
+			$itemId,
+			$message ?: 'Item lookup failed for: ' . $itemId,
+			$previous
+		);
+	}
+
+	/**
+	 * @return ItemId
+	 */
+	public function getItemId() {
+		return parent::getEntityId();
+	}
+
+}

--- a/src/Lookup/PropertyLookupException.php
+++ b/src/Lookup/PropertyLookupException.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Lookup;
+
+use Wikibase\DataModel\Entity\PropertyId;
+
+/**
+ * @since 2.0
+ *
+ * @licence GNU GPL v2+
+ * @author Adam Shorland
+ */
+class PropertyLookupException extends EntityLookupException {
+
+	public function __construct( PropertyId $propertyId, $message = null, \Exception $previous = null ) {
+		parent::__construct(
+			$propertyId,
+			$message ?: 'Property lookup failed for: ' . $propertyId,
+			$previous
+		);
+	}
+
+	/**
+	 * @return PropertyId
+	 */
+	public function getPropertyId() {
+		return parent::getEntityId();
+	}
+
+}

--- a/tests/unit/Lookup/ItemLookupExceptionTest.php
+++ b/tests/unit/Lookup/ItemLookupExceptionTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Tests\Lookup;
+
+use Wikibase\DataModel\Entity\ItemId;
+use Wikibase\DataModel\Services\Lookup\ItemLookupException;
+
+/**
+ * @covers Wikibase\DataModel\Services\Lookup\ItemLookupException
+ *
+ * @licence GNU GPL v2+
+ * @author Adam Shorland
+ */
+class ItemLookupExceptionTest extends \PHPUnit_Framework_TestCase {
+
+	public function testConstructorWithJustAnId() {
+		$itemId = new ItemId( 'Q123' );
+		$exception = new ItemLookupException( $itemId );
+
+		$this->assertEquals( $itemId, $exception->getEntityId() );
+		$this->assertEquals( $itemId, $exception->getItemId() );
+	}
+
+}

--- a/tests/unit/Lookup/PropertyLookupExceptionTest.php
+++ b/tests/unit/Lookup/PropertyLookupExceptionTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Tests\Lookup;
+
+use Wikibase\DataModel\Entity\PropertyId;
+use Wikibase\DataModel\Services\Lookup\PropertyLookupException;
+
+/**
+ * @covers Wikibase\DataModel\Services\Lookup\PropertyLookupException
+ *
+ * @licence GNU GPL v2+
+ * @author Adam Shorland
+ */
+class PropertyLookupExceptionTest extends \PHPUnit_Framework_TestCase {
+
+	public function testConstructorWithJustAnId() {
+		$propertyId = new PropertyId( 'P123' );
+		$exception = new PropertyLookupException( $propertyId );
+
+		$this->assertEquals( $propertyId, $exception->getEntityId() );
+		$this->assertEquals( $propertyId, $exception->getPropertyId() );
+	}
+
+}


### PR DESCRIPTION
These for some reason did not make it into
the last branch that was merged as they fell
out of the commit!

These are used by ItemLookup and PropertyLookup
respectively.
