### PR TITLE
Remove too specific comments

### DIFF
--- a/src/Lookup/EntityRedirectLookup.php
+++ b/src/Lookup/EntityRedirectLookup.php
@@ -22,7 +22,7 @@ interface EntityRedirectLookup {
 	 * @param EntityId $targetId
 	 *
 	 * @return EntityId[]
-	 * @throws EntityRedirectLookupException if $targetId is not known
+	 * @throws EntityRedirectLookupException
 	 */
 	public function getRedirectIds( EntityId $targetId );
 
@@ -37,7 +37,7 @@ interface EntityRedirectLookup {
 	 *
 	 * @return EntityId|null The ID of the redirect target, or null if $entityId does not refer to a
 	 * redirect.
-	 * @throws EntityRedirectLookupException if $entityId is not known
+	 * @throws EntityRedirectLookupException
 	 */
 	public function getRedirectForEntityId( EntityId $entityId, $forUpdate = '' );
 


### PR DESCRIPTION
These exceptions should be thrown for ANY exceptional case
that prevents answering of the request. Example: db connection down
