### PR TITLE
Add exception support to InMemoryEntityLookup and add tests

### DIFF
--- a/src/Lookup/InMemoryEntityLookup.php
+++ b/src/Lookup/InMemoryEntityLookup.php
@@ -37,6 +37,7 @@ class InMemoryEntityLookup implements EntityLookup {
 	}
 
 	/**
+	 * Registers an exception that will be thrown when a entity with the id in the exception is requested.
 	 * If an exception with the same EntityId was already present it will be replaced by the new one.
 	 *
 	 * @since 3.1

--- a/tests/unit/ByPropertyIdGrouperTest.php
+++ b/tests/unit/ByPropertyIdGrouperTest.php
@@ -62,16 +62,14 @@ class ByPropertyIdGrouperTest extends \PHPUnit_Framework_TestCase {
 	public function provideGetByPropertyId() {
 		$cases = array();
 
-		$propertyIdProviders = $this->getPropertyIdProviders();
-
 		$cases[] = array(
-			$propertyIdProviders,
+			$this->getPropertyIdProviders(),
 			'P42',
 			array( 'abc', 'jkl' )
 		);
 
 		$cases[] = array(
-			$propertyIdProviders,
+			$this->getPropertyIdProviders(),
 			'P23',
 			array( 'def' )
 		);
@@ -105,13 +103,11 @@ class ByPropertyIdGrouperTest extends \PHPUnit_Framework_TestCase {
 	public function provideHasPropertyId() {
 		$cases = array();
 
-		$propertyIdProviders = $this->getPropertyIdProviders();
-
-		$cases[] = array( $propertyIdProviders, 'P42', true );
-		$cases[] = array( $propertyIdProviders, 'P23', true );
-		$cases[] = array( $propertyIdProviders, 'P15', true );
-		$cases[] = array( $propertyIdProviders, 'P10', true );
-		$cases[] = array( $propertyIdProviders, 'P11', false );
+		$cases[] = array( $this->getPropertyIdProviders(), 'P42', true );
+		$cases[] = array( $this->getPropertyIdProviders(), 'P23', true );
+		$cases[] = array( $this->getPropertyIdProviders(), 'P15', true );
+		$cases[] = array( $this->getPropertyIdProviders(), 'P10', true );
+		$cases[] = array( $this->getPropertyIdProviders(), 'P11', false );
 
 		return $cases;
 	}

--- a/tests/unit/Lookup/InMemoryEntityLookupTest.php
+++ b/tests/unit/Lookup/InMemoryEntityLookupTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Tests\Lookup;
+
+use Wikibase\DataModel\Entity\ItemId;
+use Wikibase\DataModel\Services\Fixtures\FakeEntityDocument;
+use Wikibase\DataModel\Services\Lookup\EntityLookupException;
+use Wikibase\DataModel\Services\Lookup\InMemoryEntityLookup;
+
+/**
+ * @covers Wikibase\DataModel\Services\Lookup\InMemoryEntityLookup
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class InMemoryEntityLookupTest extends \PHPUnit_Framework_TestCase {
+
+	public function testGivenUnknownEntityId_getEntityReturnsNull() {
+		$lookup = new InMemoryEntityLookup();
+		$this->assertNull( $lookup->getEntity( new ItemId( 'Q1' ) ) );
+	}
+
+	public function testGivenKnownEntityId_getEntityReturnsTheEntity() {
+		$lookup = new InMemoryEntityLookup();
+
+		$lookup->addEntity( new FakeEntityDocument( new ItemId( 'Q1' ) ) );
+		$lookup->addEntity( new FakeEntityDocument( new ItemId( 'Q2' ) ) );
+		$lookup->addEntity( new FakeEntityDocument( new ItemId( 'Q3' ) ) );
+
+		$this->assertEquals(
+			new FakeEntityDocument( new ItemId( 'Q2' ) ),
+			$lookup->getEntity( new ItemId( 'Q2' ) )
+		);
+	}
+
+	public function testGivenUnknownEntityId_hasEntityReturnsFalse() {
+		$lookup = new InMemoryEntityLookup();
+		$this->assertFalse( $lookup->hasEntity( new ItemId( 'Q1' ) ) );
+	}
+
+	public function testGivenKnownEntityId_hasEntityReturnsTrue() {
+		$lookup = new InMemoryEntityLookup();
+
+		$lookup->addEntity( new FakeEntityDocument( new ItemId( 'Q1' ) ) );
+		$lookup->addEntity( new FakeEntityDocument( new ItemId( 'Q2' ) ) );
+		$lookup->addEntity( new FakeEntityDocument( new ItemId( 'Q3' ) ) );
+
+		$this->assertTrue( $lookup->hasEntity( new ItemId( 'Q2' ) ) );
+	}
+
+	public function testGivenIdInExceptionList_getEntityThrowsException() {
+		$lookup = new InMemoryEntityLookup();
+
+		$lookup->addException( new EntityLookupException( new ItemId( 'Q1' ) ) );
+
+		$lookup->getEntity( new ItemId( 'Q2' ) );
+		$this->setExpectedException( 'Wikibase\DataModel\Services\Lookup\EntityLookupException' );
+		$lookup->getEntity( new ItemId( 'Q1' ) );
+	}
+
+	public function testGivenIdInExceptionList_hasEntityThrowsException() {
+		$lookup = new InMemoryEntityLookup();
+
+		$lookup->addException( new EntityLookupException( new ItemId( 'Q1' ) ) );
+
+		$lookup->hasEntity( new ItemId( 'Q2' ) );
+		$this->setExpectedException( 'Wikibase\DataModel\Services\Lookup\EntityLookupException' );
+		$lookup->hasEntity( new ItemId( 'Q1' ) );
+	}
+
+}


### PR DESCRIPTION
> i think some of the problem is that while we have InMemoryEntityLookup
> (and think it would be nice to use in tests), it does not cover exception
> handling stuff
> 
> it would be nice to have a consistent thing to use in tests instead of
> making a mock callback in places that tries to mimic EntityLookup

-- @filbertkm
