### PR TITLE
Add all missing PHPDoc tags

### DIFF
--- a/src/ByPropertyIdGrouper.php
+++ b/src/ByPropertyIdGrouper.php
@@ -47,7 +47,10 @@ class ByPropertyIdGrouper {
 		}
 	}
 
-	private function indexPropertyIdProviders( $propertyIdProviders ) {
+	/**
+	 * @param PropertyIdProvider[] $propertyIdProviders
+	 */
+	private function indexPropertyIdProviders( array $propertyIdProviders ) {
 		foreach ( $propertyIdProviders as $propertyIdProvider ) {
 			$this->addPropertyIdProvider( $propertyIdProvider );
 		}

--- a/src/Diff/EntityDiffer.php
+++ b/src/Diff/EntityDiffer.php
@@ -48,6 +48,12 @@ class EntityDiffer {
 		}
 	}
 
+	/**
+	 * @param string $entityType
+	 *
+	 * @throws RuntimeException
+	 * @return EntityDifferStrategy
+	 */
 	private function getDiffStrategy( $entityType ) {
 		foreach ( $this->differStrategies as $diffStrategy ) {
 			if ( $diffStrategy->canDiffEntityType( $entityType ) ) {

--- a/src/Diff/EntityPatcher.php
+++ b/src/Diff/EntityPatcher.php
@@ -40,6 +40,12 @@ class EntityPatcher {
 		$this->getPatcherStrategy( $entity->getType() )->patchEntity( $entity, $patch );
 	}
 
+	/**
+	 * @param string $entityType
+	 *
+	 * @throws RuntimeException
+	 * @return EntityPatcherStrategy
+	 */
 	private function getPatcherStrategy( $entityType ) {
 		foreach ( $this->patcherStrategies as $patcherStrategy ) {
 			if ( $patcherStrategy->canPatchEntityType( $entityType ) ) {

--- a/src/Diff/Internal/FingerprintPatcher.php
+++ b/src/Diff/Internal/FingerprintPatcher.php
@@ -52,7 +52,12 @@ class FingerprintPatcher {
 		$this->patchAliases( $fingerprint, $patch->getAliasesDiff() );
 	}
 
-	private function newTermListFromArray( $termArray ) {
+	/**
+	 * @param string[] $termArray
+	 *
+	 * @return TermList
+	 */
+	private function newTermListFromArray( array $termArray ) {
 		$termList = new TermList();
 
 		foreach ( $termArray as $language => $labelText ) {
@@ -84,6 +89,11 @@ class FingerprintPatcher {
 		return $textLists;
 	}
 
+	/**
+	 * @param array[] $patchedAliases
+	 *
+	 * @return AliasGroupList
+	 */
 	private function getAliasesFromArrayForPatching( array $patchedAliases ) {
 		$aliases = new AliasGroupList();
 

--- a/src/Diff/Internal/SiteLinkListPatcher.php
+++ b/src/Diff/Internal/SiteLinkListPatcher.php
@@ -54,6 +54,11 @@ class SiteLinkListPatcher {
 		return $patchedSiteLinks;
 	}
 
+	/**
+	 * @param string[] $siteLinkData
+	 *
+	 * @return ItemId[]|null
+	 */
 	private function getBadgesFromSiteLinkData( array $siteLinkData ) {
 		if ( !array_key_exists( 'badges', $siteLinkData ) ) {
 			return null;

--- a/src/Diff/PropertyDiffer.php
+++ b/src/Diff/PropertyDiffer.php
@@ -3,6 +3,7 @@
 namespace Wikibase\DataModel\Services\Diff;
 
 use Diff\Differ\MapDiffer;
+use Diff\DiffOp\DiffOp;
 use InvalidArgumentException;
 use Wikibase\DataModel\Entity\EntityDocument;
 use Wikibase\DataModel\Entity\Property;
@@ -72,10 +73,21 @@ class PropertyDiffer implements EntityDifferStrategy {
 		return new EntityDiff( $diffOps );
 	}
 
+	/**
+	 * @param array[] $from
+	 * @param array[] $to
+	 *
+	 * @return DiffOp[]
+	 */
 	private function diffPropertyArrays( array $from, array $to ) {
 		return $this->recursiveMapDiffer->doDiff( $from, $to );
 	}
 
+	/**
+	 * @param Property $property
+	 *
+	 * @return array[]
+	 */
 	private function toDiffArray( Property $property ) {
 		$array = array();
 

--- a/src/Lookup/EntityLookupException.php
+++ b/src/Lookup/EntityLookupException.php
@@ -2,6 +2,8 @@
 
 namespace Wikibase\DataModel\Services\Lookup;
 
+use Exception;
+use RuntimeException;
 use Wikibase\DataModel\Entity\EntityId;
 
 /**
@@ -10,11 +12,19 @@ use Wikibase\DataModel\Entity\EntityId;
  * @licence GNU GPL v2+
  * @author Adam Shorland
  */
-class EntityLookupException extends \RuntimeException {
+class EntityLookupException extends RuntimeException {
 
+	/**
+	 * @var EntityId
+	 */
 	private $entityId;
 
-	public function __construct( EntityId $entityId, $message = null, \Exception $previous = null ) {
+	/**
+	 * @param EntityId $entityId
+	 * @param string|null $message
+	 * @param Exception|null $previous
+	 */
+	public function __construct( EntityId $entityId, $message = null, Exception $previous = null ) {
 		$this->entityId = $entityId;
 
 		parent::__construct(

--- a/src/Lookup/EntityRedirectLookupException.php
+++ b/src/Lookup/EntityRedirectLookupException.php
@@ -2,6 +2,8 @@
 
 namespace Wikibase\DataModel\Services\Lookup;
 
+use Exception;
+use RuntimeException;
 use Wikibase\DataModel\Entity\EntityId;
 
 /**
@@ -10,11 +12,19 @@ use Wikibase\DataModel\Entity\EntityId;
  * @licence GNU GPL v2+
  * @author Adam Shorland
  */
-class EntityRedirectLookupException extends \RuntimeException {
+class EntityRedirectLookupException extends RuntimeException {
 
+	/**
+	 * @var EntityId
+	 */
 	private $entityId;
 
-	public function __construct( EntityId $entityId, $message = null, \Exception $previous = null ) {
+	/**
+	 * @param EntityId $entityId
+	 * @param string|null $message
+	 * @param Exception|null $previous
+	 */
+	public function __construct( EntityId $entityId, $message = null, Exception $previous = null ) {
 		$this->entityId = $entityId;
 
 		parent::__construct(

--- a/src/Lookup/EntityRetrievingDataTypeLookup.php
+++ b/src/Lookup/EntityRetrievingDataTypeLookup.php
@@ -16,6 +16,9 @@ use Wikibase\DataModel\Entity\PropertyId;
  */
 class EntityRetrievingDataTypeLookup implements PropertyDataTypeLookup {
 
+	/**
+	 * @var EntityLookup
+	 */
 	private $entityLookup;
 
 	public function __construct( EntityLookup $entityLookup ) {

--- a/src/Lookup/InMemoryDataTypeLookup.php
+++ b/src/Lookup/InMemoryDataTypeLookup.php
@@ -17,6 +17,9 @@ use Wikibase\DataModel\Entity\PropertyId;
  */
 class InMemoryDataTypeLookup implements PropertyDataTypeLookup {
 
+	/**
+	 * @var string[]
+	 */
 	private $dataTypeIds = array();
 
 	/**
@@ -36,12 +39,19 @@ class InMemoryDataTypeLookup implements PropertyDataTypeLookup {
 	 *
 	 * @param PropertyId $propertyId
 	 * @param string $dataTypeId
+	 *
+	 * @throws InvalidArgumentException
 	 */
 	public function setDataTypeForProperty( PropertyId $propertyId, $dataTypeId ) {
 		$this->verifyDataTypeIdType( $dataTypeId );
 		$this->dataTypeIds[$propertyId->getSerialization()] = $dataTypeId;
 	}
 
+	/**
+	 * @param PropertyId $propertyId
+	 *
+	 * @throws PropertyDataTypeLookupException
+	 */
 	private function verifyDataTypeIsSet( PropertyId $propertyId ) {
 		$numericId = $propertyId->getSerialization();
 
@@ -50,6 +60,11 @@ class InMemoryDataTypeLookup implements PropertyDataTypeLookup {
 		}
 	}
 
+	/**
+	 * @param string $dataTypeId
+	 *
+	 * @throws InvalidArgumentException
+	 */
 	private function verifyDataTypeIdType( $dataTypeId ) {
 		if ( !is_string( $dataTypeId ) ) {
 			throw new InvalidArgumentException( '$dataTypeId must be a string; got ' . gettype( $dataTypeId ) );

--- a/src/Lookup/InMemoryEntityLookup.php
+++ b/src/Lookup/InMemoryEntityLookup.php
@@ -20,7 +20,14 @@ use Wikibase\DataModel\Entity\EntityId;
  */
 class InMemoryEntityLookup implements EntityLookup {
 
+	/**
+	 * @var EntityDocument[]
+	 */
 	private $entities = array();
+
+	/**
+	 * @var EntityLookupException[]
+	 */
 	private $exceptions = array();
 
 	/**

--- a/src/Lookup/ItemLookupException.php
+++ b/src/Lookup/ItemLookupException.php
@@ -2,6 +2,7 @@
 
 namespace Wikibase\DataModel\Services\Lookup;
 
+use Exception;
 use Wikibase\DataModel\Entity\ItemId;
 
 /**
@@ -12,7 +13,12 @@ use Wikibase\DataModel\Entity\ItemId;
  */
 class ItemLookupException extends EntityLookupException {
 
-	public function __construct( ItemId $itemId, $message = null, \Exception $previous = null ) {
+	/**
+	 * @param ItemId $itemId
+	 * @param string|null $message
+	 * @param Exception|null $previous
+	 */
+	public function __construct( ItemId $itemId, $message = null, Exception $previous = null ) {
 		parent::__construct(
 			$itemId,
 			$message ?: 'Item lookup failed for: ' . $itemId,

--- a/src/Lookup/LabelDescriptionLookupException.php
+++ b/src/Lookup/LabelDescriptionLookupException.php
@@ -2,6 +2,8 @@
 
 namespace Wikibase\DataModel\Services\Lookup;
 
+use Exception;
+use RuntimeException;
 use Wikibase\DataModel\Entity\EntityId;
 
 /**
@@ -10,11 +12,19 @@ use Wikibase\DataModel\Entity\EntityId;
  * @licence GNU GPL v2+
  * @author Adam Shorland
  */
-class LabelDescriptionLookupException extends \RuntimeException {
+class LabelDescriptionLookupException extends RuntimeException {
 
+	/**
+	 * @var EntityId
+	 */
 	private $entityId;
 
-	public function __construct( EntityId $entityId, $message = null, \Exception $previous = null ) {
+	/**
+	 * @param EntityId $entityId
+	 * @param string|null $message
+	 * @param Exception|null $previous
+	 */
+	public function __construct( EntityId $entityId, $message = null, Exception $previous = null ) {
 		$this->entityId = $entityId;
 
 		parent::__construct(

--- a/src/Lookup/PropertyDataTypeLookupException.php
+++ b/src/Lookup/PropertyDataTypeLookupException.php
@@ -2,6 +2,8 @@
 
 namespace Wikibase\DataModel\Services\Lookup;
 
+use Exception;
+use RuntimeException;
 use Wikibase\DataModel\Entity\PropertyId;
 
 /**
@@ -10,11 +12,19 @@ use Wikibase\DataModel\Entity\PropertyId;
  * @licence GNU GPL v2+
  * @author Adam Shorland
  */
-class PropertyDataTypeLookupException extends \RuntimeException {
+class PropertyDataTypeLookupException extends RuntimeException {
 
+	/**
+	 * @var PropertyId
+	 */
 	private $propertyId;
 
-	public function __construct( PropertyId $propertyId, $message = null, \Exception $previous = null ) {
+	/**
+	 * @param PropertyId $propertyId
+	 * @param string|null $message
+	 * @param Exception|null $previous
+	 */
+	public function __construct( PropertyId $propertyId, $message = null, Exception $previous = null ) {
 		$this->propertyId = $propertyId;
 
 		parent::__construct(

--- a/src/Lookup/PropertyLookupException.php
+++ b/src/Lookup/PropertyLookupException.php
@@ -2,6 +2,7 @@
 
 namespace Wikibase\DataModel\Services\Lookup;
 
+use Exception;
 use Wikibase\DataModel\Entity\PropertyId;
 
 /**
@@ -12,7 +13,12 @@ use Wikibase\DataModel\Entity\PropertyId;
  */
 class PropertyLookupException extends EntityLookupException {
 
-	public function __construct( PropertyId $propertyId, $message = null, \Exception $previous = null ) {
+	/**
+	 * @param PropertyId $propertyId
+	 * @param string|null $message
+	 * @param Exception|null $previous
+	 */
+	public function __construct( PropertyId $propertyId, $message = null, Exception $previous = null ) {
 		parent::__construct(
 			$propertyId,
 			$message ?: 'Property lookup failed for: ' . $propertyId,

--- a/src/Lookup/TermLookupException.php
+++ b/src/Lookup/TermLookupException.php
@@ -2,6 +2,8 @@
 
 namespace Wikibase\DataModel\Services\Lookup;
 
+use Exception;
+use RuntimeException;
 use Wikibase\DataModel\Entity\EntityId;
 
 /**
@@ -10,15 +12,24 @@ use Wikibase\DataModel\Entity\EntityId;
  * @licence GNU GPL v2+
  * @author Adam Shorland
  */
-class TermLookupException extends \RuntimeException {
+class TermLookupException extends RuntimeException {
 
+	/**
+	 * @var EntityId
+	 */
 	private $entityId;
 
+	/**
+	 * @param EntityId $entityId
+	 * @param string[] $languageCodes
+	 * @param string|null $message
+	 * @param Exception|null $previous
+	 */
 	public function __construct(
 		EntityId $entityId,
 		array $languageCodes,
 		$message = null,
-		\Exception $previous = null
+		Exception $previous = null
 	) {
 		$this->entityId = $entityId;
 

--- a/src/Statement/StatementGuidParsingException.php
+++ b/src/Statement/StatementGuidParsingException.php
@@ -2,12 +2,14 @@
 
 namespace Wikibase\DataModel\Services\Statement;
 
+use RuntimeException;
+
 /**
  * @since 1.0
  *
  * @licence GNU GPL v2+
  * @author Adam Shorland
  */
-class StatementGuidParsingException extends \RuntimeException {
+class StatementGuidParsingException extends RuntimeException {
 
 }

--- a/tests/fixtures/EntityOfUnknownType.php
+++ b/tests/fixtures/EntityOfUnknownType.php
@@ -10,6 +10,9 @@ use Wikibase\DataModel\Entity\EntityDocument;
  */
 class EntityOfUnknownType implements EntityDocument {
 
+	/**
+	 * @return null
+	 */
 	public function getId() {
 		return null;
 	}
@@ -18,9 +21,15 @@ class EntityOfUnknownType implements EntityDocument {
 		return 'unknown-entity-type';
 	}
 
+	/**
+	 * @param mixed $id Ignored.
+	 */
 	public function setId( $id ) {
 	}
 
+	/**
+	 * @return bool Always true.
+	 */
 	public function isEmpty() {
 		return true;
 	}

--- a/tests/fixtures/FakeEntityDocument.php
+++ b/tests/fixtures/FakeEntityDocument.php
@@ -11,24 +11,42 @@ use Wikibase\DataModel\Entity\EntityId;
  */
 class FakeEntityDocument implements EntityDocument {
 
+	/**
+	 * @var EntityId
+	 */
 	private $id;
 
+	/**
+	 * @param EntityId $id
+	 */
 	public function __construct( EntityId $id ) {
 		$this->id = $id;
 	}
 
+	/**
+	 * @return EntityId
+	 */
 	public function getId() {
 		return $this->id;
 	}
 
+	/**
+	 * @return string
+	 */
 	public function getType() {
 		return $this->id->getEntityType();
 	}
 
+	/**
+	 * @param EntityId $id
+	 */
 	public function setId( $id ) {
 		$this->id = $id;
 	}
 
+	/**
+	 * @return bool
+	 */
 	public function isEmpty() {
 		return true;
 	}

--- a/tests/unit/Diff/EntityDiffOldTest.php
+++ b/tests/unit/Diff/EntityDiffOldTest.php
@@ -126,7 +126,6 @@ abstract class EntityDiffOldTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 *
 	 * @dataProvider provideApplyData
 	 */
 	public function testApply( Entity $a, Entity $b ) {

--- a/tests/unit/Lookup/EntityRetrievingDataTypeLookupTest.php
+++ b/tests/unit/Lookup/EntityRetrievingDataTypeLookupTest.php
@@ -16,6 +16,9 @@ use Wikibase\DataModel\Services\Lookup\InMemoryEntityLookup;
  */
 class EntityRetrievingDataTypeLookupTest extends \PHPUnit_Framework_TestCase {
 
+	/**
+	 * @var string[]
+	 */
 	private $propertiesAndTypes = array(
 		'P1' => 'NyanData all the way across the sky',
 		'P42' => 'string',


### PR DESCRIPTION
I find PHPDoc tags for class properties extremely helpful, if not critical, because it saves one from scanning the whole file for the intended type.

I'm _not_ adding tags in cases where it's really, really obvious from the method signature.
