### PR TITLE
Introduce PropertyDataTypeMatcher

### DIFF
--- a/src/Lookup/InProcessCachingDataTypeLookup.php
+++ b/src/Lookup/InProcessCachingDataTypeLookup.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Lookup;
+
+use Wikibase\DataModel\Entity\PropertyId;
+
+/**
+ * PropertyDataTypeLookup that provides in-process caching.
+ *
+ * @since 3.1
+ *
+ * @licence GNU GPL v2+
+ * @author Katie Filbert < aude.wiki@gmail.com >
+ */
+class InProcessCachingDataTypeLookup implements PropertyDataTypeLookup {
+
+	/**
+	 * @var string[] Indexed by serialized PropertyId
+	 */
+	private $propertyIds = array();
+
+	/**
+	 * @param PropertyDataTypeLookup $propertyDataTypeLookup
+	 */
+	public function __construct( PropertyDataTypeLookup $propertyDataTypeLookup ) {
+		$this->propertyDataTypeLookup = $propertyDataTypeLookup;
+	}
+
+	/**
+	 * @param PropertyId $propertyId
+	 *
+	 * @return string
+	 * @throws PropertyDataTypeLookupException
+	 */
+	public function getDataTypeIdForProperty( PropertyId $propertyId ) {
+		$serializedId = $propertyId->getSerialization();
+
+		if ( !array_key_exists( $serializedId, $this->propertyIds ) ) {
+			$dataTypeId = $this->propertyDataTypeLookup->getDataTypeIdFOrProperty( $propertyId );
+			$this->propertyIds[$serializedId] = $dataTypeId;
+		}
+
+		return $this->propertyIds[$serializedId];
+	}
+
+}

--- a/src/Lookup/PropertyDataTypeMatcher.php
+++ b/src/Lookup/PropertyDataTypeMatcher.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Lookup;
+
+use Wikibase\DataModel\Entity\PropertyId;
+
+/**
+ * Check if a PropertyId is for a Property with a specific data type.
+ *
+ * @license GNU GPL v2+
+ * @author Katie Filbert < aude.wiki@gmail.com >
+ */
+class PropertyDataTypeMatcher {
+
+	/**
+	 * @var PropertyDataTypeLookup
+	 */
+	private $propertyDataTypeLookup;
+
+	/**
+	 * @param PropertyDataTypeLookup $propertyDataTypeLookup
+	 */
+	public function __construct( PropertyDataTypeLookup $propertyDataTypeLookup ) {
+		$this->propertyDataTypeLookup = $propertyDataTypeLookup;
+	}
+
+	/**
+	 * @param PropertyId $propertyId
+	 * @param string $dataType
+	 *
+	 * @return bool
+	 */
+	public function isMatchingDataType( PropertyId $propertyId, $dataType ) {
+		try {
+			return $this->findDataTypeIdForProperty( $propertyId ) === $dataType;
+		} catch ( PropertyDataTypeLookupException $ex ) {
+			return false;
+		}
+	}
+
+	/**
+	 * @param PropertyId $propertyId
+	 *
+	 * @return string
+	 * @throws PropertyDataTypeLookupException
+	 */
+	private function findDataTypeIdForProperty( PropertyId $propertyId ) {
+		return $this->propertyDataTypeLookup->getDataTypeIdForProperty( $propertyId );
+	}
+
+}

--- a/tests/unit/Lookup/InProcessCachingDataTypeLookupTest.php
+++ b/tests/unit/Lookup/InProcessCachingDataTypeLookupTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Wikibase\Lib\Tests\Store;
+
+use PHPUnit_Framework_TestCase;
+use Wikibase\DataModel\Entity\PropertyId;
+use Wikibase\DataModel\Services\Lookup\InProcessCachingDataTypeLookup;
+
+/**
+ * @covers Wikibase\DataModel\Services\Lookup\InProcessCachingDataTypeLookup
+ *
+ * @licence GNU GPL v2+
+ * @author Katie Filbert < aude.wiki@gmail.com >
+ */
+class InProcessCachingDataTypeLookupTest extends PHPUnit_Framework_TestCase {
+
+	public function testIsMatchingDataTypeInProcessCaching() {
+		$propertyDataTypeLookup = $this->getMock(
+			'Wikibase\DataModel\Services\Lookup\PropertyDataTypeLookup'
+		);
+
+		$propertyDataTypeLookup->expects( $this->once() )
+			->method( 'getDataTypeIdForProperty' )
+			->with( new PropertyId( 'P1' ) )
+			->will( $this->returnValue( 'string' ) );
+
+		$cachingDataTypeLookup = new InProcessCachingDataTypeLookup( $propertyDataTypeLookup );
+
+		$dataType = $cachingDataTypeLookup->getDataTypeIdForProperty( new PropertyId( 'P1' ) );
+		$dataType = $cachingDataTypeLookup->getDataTypeIdForProperty( new PropertyId( 'P1' ) );
+
+		$this->assertEquals(
+			'string',
+			$dataType,
+			'P1 has string data type and non-caching PropertyDataTypeLookup invoked only once.'
+		);
+	}
+
+}

--- a/tests/unit/Lookup/PropertyDataTypeMatcherTest.php
+++ b/tests/unit/Lookup/PropertyDataTypeMatcherTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Wikibase\Lib\Tests\Store;
+
+use PHPUnit_Framework_TestCase;
+use Wikibase\DataModel\Entity\PropertyId;
+use Wikibase\DataModel\Services\Lookup\InMemoryDataTypeLookup;
+use Wikibase\DataModel\Services\Lookup\InProcessCachingDataTypeLookup;
+use Wikibase\DataModel\Services\Lookup\PropertyDataTypeMatcher;
+
+/**
+ * @covers Wikibase\DataModel\Services\Lookup\PropertyDataTypeMatcher
+ *
+ * @licence GNU GPL v2+
+ * @author Katie Filbert < aude.wiki@gmail.com >
+ */
+class PropertyDataTypeMatcherTest extends PHPUnit_Framework_TestCase {
+
+	public function testIsMatchingDataType() {
+		$propertyDataTypeMatcher = $this->getPropertyDataTypeMatcher();
+
+		$isMatching = $propertyDataTypeMatcher->isMatchingDataType(
+			new PropertyId( 'P2' ),
+			'string'
+		);
+
+		$this->assertTrue( $isMatching, 'P2 matches commonsMedia data type.' );
+	}
+
+	public function testIsMatchingDataTypeNotmatch() {
+		$propertyDataTypeMatcher = $this->getPropertyDataTypeMatcher();
+
+		$isMatching = $propertyDataTypeMatcher->isMatchingDataType(
+			new PropertyId( 'P2' ),
+			'url'
+		);
+
+		$this->assertFalse( $isMatching, 'P2 does not match url data type.' );
+	}
+
+	public function testIsMatchingDataTypeUnknownPropertyId() {
+		$propertyDataTypeMatcher = $this->getPropertyDataTypeMatcher();
+
+		$isMatching = $propertyDataTypeMatcher->isMatchingDataType(
+			new PropertyId( 'P9000' ),
+			'string'
+		);
+
+		$this->assertFalse( $isMatching, 'Lookup of unknown property returns false.' );
+	}
+
+	private function getPropertyDataTypeMatcher() {
+		$inMemoryDataTypeLookup = new InMemoryDataTypeLookup();
+		$inMemoryDataTypeLookup->setDataTypeForProperty( new PropertyId( 'P2' ), 'string' );
+
+		$propertyDataTypeLookup = new InProcessCachingDataTypeLookup( $inMemoryDataTypeLookup );
+
+		return new PropertyDataTypeMatcher( $propertyDataTypeLookup );
+	}
+
+}


### PR DESCRIPTION
This wraps around PropertyDataTypeLookup to check if a Property has a given data type, with in process caching for performance reasons.
