### PR TITLE
Fix type hint in ByPropertyIdGrouper

### DIFF
--- a/phpmd.xml
+++ b/phpmd.xml
@@ -8,9 +8,6 @@
         <exclude name="ExcessiveClassComplexity" />
         <exclude name="TooManyPublicMethods" />
     </rule>
-    <rule name="rulesets/codesize.xml/TooManyPublicMethods">
-        <exclude-pattern>tests/unit/</exclude-pattern>
-    </rule>
 
     <rule ref="rulesets/controversial.xml">
         <exclude name="CamelCaseMethodName" />

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -9,6 +9,12 @@
         <exclude name="TooManyPublicMethods" />
     </rule>
 
+    <rule ref="rulesets/codesize.xml/TooManyPublicMethods">
+        <properties>
+            <property name="ignorepattern" value="(^(set|get|test))i" />
+        </properties>
+    </rule>
+
     <rule ref="rulesets/controversial.xml">
         <exclude name="CamelCaseMethodName" />
     </rule>

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -6,6 +6,10 @@
 
     <rule ref="rulesets/codesize.xml">
         <exclude name="ExcessiveClassComplexity" />
+        <exclude name="TooManyPublicMethods" />
+    </rule>
+    <rule name="rulesets/codesize.xml/TooManyPublicMethods">
+        <exclude-pattern>tests/unit/</exclude-pattern>
     </rule>
 
     <rule ref="rulesets/controversial.xml">

--- a/src/ByPropertyIdGrouper.php
+++ b/src/ByPropertyIdGrouper.php
@@ -48,9 +48,9 @@ class ByPropertyIdGrouper {
 	}
 
 	/**
-	 * @param PropertyIdProvider[] $propertyIdProviders
+	 * @param PropertyIdProvider[]|Traversable $propertyIdProviders
 	 */
-	private function indexPropertyIdProviders( array $propertyIdProviders ) {
+	private function indexPropertyIdProviders( $propertyIdProviders ) {
 		foreach ( $propertyIdProviders as $propertyIdProvider ) {
 			$this->addPropertyIdProvider( $propertyIdProvider );
 		}

--- a/tests/unit/ByPropertyIdGrouperTest.php
+++ b/tests/unit/ByPropertyIdGrouperTest.php
@@ -2,10 +2,12 @@
 
 namespace Wikibase\DataModel\Services\Tests;
 
+use ArrayObject;
 use OutOfBoundsException;
-use Wikibase\DataModel\Services\ByPropertyIdGrouper;
+use PHPUnit_Framework_TestCase;
 use Wikibase\DataModel\Entity\PropertyId;
 use Wikibase\DataModel\PropertyIdProvider;
+use Wikibase\DataModel\Services\ByPropertyIdGrouper;
 use Wikibase\DataModel\Snak\Snak;
 
 /**
@@ -13,8 +15,45 @@ use Wikibase\DataModel\Snak\Snak;
  *
  * @license GNU GPL v2+
  * @author Bene* < benestar.wikimedia@gmail.com >
+ * @author Thiemo Mättig
  */
-class ByPropertyIdGrouperTest extends \PHPUnit_Framework_TestCase {
+class ByPropertyIdGrouperTest extends PHPUnit_Framework_TestCase {
+
+	/**
+	 * @dataProvider validConstructorArgumentProvider
+	 */
+	public function testConstructor( $argument ) {
+		$instance = new ByPropertyIdGrouper( $argument );
+		$this->assertCount( count( $argument ), $instance->getPropertyIds() );
+	}
+
+	public function validConstructorArgumentProvider() {
+		return array(
+			array( array() ),
+			array( array( $this->getPropertyIdProviderMock( 'P1' ) ) ),
+			array( new ArrayObject() ),
+			array( new ArrayObject( array( $this->getPropertyIdProviderMock( 'P1' ) ) ) ),
+		);
+	}
+
+	/**
+	 * @dataProvider invalidConstructorArgumentProvider
+	 */
+	public function testConstructorThrowsException( $argument ) {
+		$this->setExpectedException( 'InvalidArgumentException' );
+		new ByPropertyIdGrouper( $argument );
+	}
+
+	public function invalidConstructorArgumentProvider() {
+		return array(
+			array( null ),
+			array( 'notAnObject' ),
+			array( array( null ) ),
+			array( array( 'notAnObject' ) ),
+			array( new ArrayObject( array( null ) ) ),
+			array( new ArrayObject( array( 'notAnObject' ) ) ),
+		);
+	}
 
 	public function provideGetPropertyIds() {
 		$cases = array();
@@ -79,9 +118,6 @@ class ByPropertyIdGrouperTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider provideGetByPropertyId
-	 * @param PropertyIdProvider[] $propertyIdProviders
-	 * @param string $propertyId
-	 * @param string[] $expectedValues
 	 */
 	public function testGetByPropertyId( array $propertyIdProviders, $propertyId, array $expectedValues ) {
 		$byPropertyIdGrouper = new ByPropertyIdGrouper( $propertyIdProviders );
@@ -114,9 +150,6 @@ class ByPropertyIdGrouperTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider provideHasPropertyId
-	 * @param PropertyIdProvider[] $propertyIdProviders
-	 * @param string $propertyId
-	 * @param bool $expectedValue
 	 */
 	public function testHasPropertyId( array $propertyIdProviders, $propertyId, $expectedValue ) {
 		$byPropertyIdGrouper = new ByPropertyIdGrouper( $propertyIdProviders );
@@ -141,12 +174,13 @@ class ByPropertyIdGrouperTest extends \PHPUnit_Framework_TestCase {
 	 *
 	 * @param string $propertyId
 	 * @param string|null $type
+	 *
 	 * @return PropertyIdProvider
 	 */
 	private function getPropertyIdProviderMock( $propertyId, $type = null ) {
 		$propertyIdProvider = $this->getMock( 'Wikibase\DataModel\Snak\Snak' );
 
-		$propertyIdProvider->expects( $this->any() )
+		$propertyIdProvider->expects( $this->once() )
 			->method( 'getPropertyId' )
 			->will( $this->returnValue( new PropertyId( $propertyId ) ) );
 


### PR DESCRIPTION
indexPropertyIdProviders is called from __construct with
`PropertyIdProvider[]|Traversable`.
