### PR TITLE
Remove unused use clause from TermLookup

### DIFF
--- a/src/Lookup/TermLookup.php
+++ b/src/Lookup/TermLookup.php
@@ -2,7 +2,6 @@
 
 namespace Wikibase\DataModel\Services\Lookup;
 
-use OutOfBoundsException;
 use Wikibase\DataModel\Entity\EntityId;
 
 /**


### PR DESCRIPTION
This is the only unused one I can find in this component.
