### PR TITLE
Add EntityDifferStrategy::canDiffEntityTypes

### DIFF
--- a/src/Diff/EntityDiffer.php
+++ b/src/Diff/EntityDiffer.php
@@ -39,7 +39,8 @@ class EntityDiffer {
 	public function diffEntities( EntityDocument $from, EntityDocument $to ) {
 		$this->assertTypesMatch( $from, $to );
 
-		return $this->getDiffStrategy( $from->getType() )->diffEntities( $from, $to );
+		$differ = $this->getDiffStrategy( $from->getType(), $to->getType() );
+		return $differ->diffEntities( $from, $to );
 	}
 
 	private function assertTypesMatch( EntityDocument $from, EntityDocument $to ) {
@@ -49,14 +50,15 @@ class EntityDiffer {
 	}
 
 	/**
-	 * @param string $entityType
+	 * @param string $fromType
+	 * @param string $toType
 	 *
 	 * @throws RuntimeException
 	 * @return EntityDifferStrategy
 	 */
-	private function getDiffStrategy( $entityType ) {
+	private function getDiffStrategy( $fromType, $toType ) {
 		foreach ( $this->differStrategies as $diffStrategy ) {
-			if ( $diffStrategy->canDiffEntityType( $entityType ) ) {
+			if ( $diffStrategy->canDiffEntityTypes( $fromType, $toType ) ) {
 				return $diffStrategy;
 			}
 		}
@@ -71,7 +73,8 @@ class EntityDiffer {
 	 * @throws InvalidArgumentException
 	 */
 	public function getConstructionDiff( EntityDocument $entity ) {
-		return $this->getDiffStrategy( $entity->getType() )->getConstructionDiff( $entity );
+		$type = $entity->getType();
+		return $this->getDiffStrategy( $type, $type )->getConstructionDiff( $entity );
 	}
 
 	/**
@@ -81,7 +84,8 @@ class EntityDiffer {
 	 * @throws InvalidArgumentException
 	 */
 	public function getDestructionDiff( EntityDocument $entity ) {
-		return $this->getDiffStrategy( $entity->getType() )->getDestructionDiff( $entity );
+		$type = $entity->getType();
+		return $this->getDiffStrategy( $type, $type )->getDestructionDiff( $entity );
 	}
 
 }

--- a/src/Diff/EntityDifferStrategy.php
+++ b/src/Diff/EntityDifferStrategy.php
@@ -14,11 +14,14 @@ use Wikibase\DataModel\Entity\EntityDocument;
 interface EntityDifferStrategy {
 
 	/**
-	 * @param string $entityType
+	 * @since 4.0
 	 *
-	 * @return boolean
+	 * @param string $fromType
+	 * @param string $toType
+	 *
+	 * @return bool
 	 */
-	public function canDiffEntityType( $entityType );
+	public function canDiffEntityTypes( $fromType, $toType );
 
 	/**
 	 * @param EntityDocument $from

--- a/src/Diff/ItemDiffer.php
+++ b/src/Diff/ItemDiffer.php
@@ -33,12 +33,15 @@ class ItemDiffer implements EntityDifferStrategy {
 	}
 
 	/**
-	 * @param string $entityType
+	 * @since 4.0
+	 *
+	 * @param string $fromType
+	 * @param string $toType
 	 *
 	 * @return bool
 	 */
-	public function canDiffEntityType( $entityType ) {
-		return $entityType === 'item';
+	public function canDiffEntityTypes( $fromType, $toType ) {
+		return $fromType === 'item' && $toType === 'item';
 	}
 
 	/**

--- a/src/Diff/PropertyDiffer.php
+++ b/src/Diff/PropertyDiffer.php
@@ -33,12 +33,15 @@ class PropertyDiffer implements EntityDifferStrategy {
 	}
 
 	/**
-	 * @param string $entityType
+	 * @since 4.0
+	 *
+	 * @param string $fromType
+	 * @param string $toType
 	 *
 	 * @return bool
 	 */
-	public function canDiffEntityType( $entityType ) {
-		return $entityType === 'property';
+	public function canDiffEntityTypes( $fromType, $toType ) {
+		return $fromType === 'property' && $toType === 'property';
 	}
 
 	/**


### PR DESCRIPTION
This is split from #61.

The fact that we currently do not support diffs between different types of entities should not be hardcoded so deep in the system. I believe that what I do in this patch makes the code easier to understand. Look at this line:

``` php
$this->getDiffStrategy( $from->getType() )->diffEntities( $from, $to )
```

It looks suspicious. How can the strategy be based on **one** side, when the diff does have two? This patch fixes this.
