### PR TITLE
Rename $autoLoader to $classLoader

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -18,9 +18,9 @@ if ( !is_readable( __DIR__ . '/../vendor/autoload.php' ) ) {
 	die( 'You need to install this package with Composer before you can run the tests' );
 }
 
-$autoLoader = require __DIR__ . '/../vendor/autoload.php';
+$classLoader = require __DIR__ . '/../vendor/autoload.php';
 
-$autoLoader->addPsr4( 'Wikibase\\DataModel\\Services\\Tests\\', __DIR__ . '/unit/' );
-$autoLoader->addPsr4( 'Wikibase\\DataModel\\Services\\Fixtures\\', __DIR__ . '/fixtures/' );
+$classLoader->addPsr4( 'Wikibase\\DataModel\\Services\\Tests\\', __DIR__ . '/unit/' );
+$classLoader->addPsr4( 'Wikibase\\DataModel\\Services\\Fixtures\\', __DIR__ . '/fixtures/' );
 
-unset( $autoLoader );
+unset( $classLoader );


### PR DESCRIPTION
I find it helpful when the var name gives a hint that it is of type `ClassLoader`.

Also see:
- https://github.com/wmde/WikibaseDataModel/pull/582
- https://github.com/wmde/WikibaseInternalSerialization/pull/89
