### PR TITLE
Escaping formatter doesn't always return HTML

### DIFF
--- a/src/EntityId/EscapingEntityIdFormatter.php
+++ b/src/EntityId/EscapingEntityIdFormatter.php
@@ -28,7 +28,8 @@ class EscapingEntityIdFormatter implements EntityIdFormatter {
 
 	/**
 	 * @param EntityIdFormatter $formatter
-	 * @param callable $escapeCallback A callable taking plain text and returning escaped HTML
+	 * @param callable $escapeCallback A callable taking plain text and returning escaped text.
+	 *
 	 * @throws InvalidArgumentException
 	 */
 	public function __construct( EntityIdFormatter $formatter, $escapeCallback ) {
@@ -41,9 +42,8 @@ class EscapingEntityIdFormatter implements EntityIdFormatter {
 	}
 
 	/**
-	 * Format an EntityId
-	 *
 	 * @param EntityId $value
+	 *
 	 * @return string
 	 */
 	public function formatEntityId( EntityId $value ) {


### PR DESCRIPTION
I think this qualifies as a bug in the documentation.
