### PR TITLE
Re-enable two disabled PHPMD rules

### DIFF
--- a/phpmd.xml
+++ b/phpmd.xml
@@ -5,8 +5,13 @@
          xsi:noNamespaceSchemaLocation=" http://pmd.sf.net/ruleset_xml_schema.xsd">
 
     <rule ref="rulesets/codesize.xml">
-        <exclude name="ExcessiveClassComplexity" />
+        <exclude name="ExcessiveMethodLength" />
         <exclude name="TooManyPublicMethods" />
+    </rule>
+    <rule ref="rulesets/codesize.xml/ExcessiveMethodLength">
+        <properties>
+            <property name="minimum" value="139" />
+        </properties>
     </rule>
     <rule ref="rulesets/codesize.xml/TooManyPublicMethods">
         <properties>

--- a/tests/unit/Diff/ItemDiffTest.php
+++ b/tests/unit/Diff/ItemDiffTest.php
@@ -15,8 +15,6 @@ use Wikibase\DataModel\SiteLink;
 /**
  * @covers Wikibase\DataModel\Services\Diff\ItemDiff
  *
- * @SuppressWarnings(PHPMD)
- *
  * @license GPL-2.0+
  * @author Daniel Kinzler
  * @author Jens Ohlig <jens.ohlig@wikimedia.de>


### PR DESCRIPTION
This patch re-enables two PHPMD rules that are currently disabled entirely: ExcessiveClassComplexity, and ExcessiveMethodLength. The default "minimum" for ExcessiveMethodLength is 100. ItemDiffTest breaks this, that's why I set it to 139 for now.