### PR TITLE
Fix inconsistent StatementGuid creation and parsing

### DIFF
--- a/src/Statement/StatementGuidParser.php
+++ b/src/Statement/StatementGuidParser.php
@@ -7,6 +7,11 @@ use Wikibase\DataModel\Entity\EntityIdParsingException;
 use Wikibase\DataModel\Statement\StatementGuid;
 
 /**
+ * A parser capable of splitting a statement id into the entity id of the entity the statement
+ * belongs to, and the randomly generated global unique identifier (GUID).
+ *
+ * @see StatementGuid
+ *
  * @since 1.0
  *
  * @licence GNU GPL v2+
@@ -34,10 +39,10 @@ class StatementGuidParser {
 	 */
 	public function parse( $serialization ) {
 		if ( !is_string( $serialization ) ) {
-			throw new StatementGuidParsingException( '$serialization must be a string; got ' . gettype( $serialization ) );
+			throw new StatementGuidParsingException( '$serialization must be a string' );
 		}
 
-		$keyParts = explode( StatementGuid::SEPARATOR, $serialization );
+		$keyParts = explode( StatementGuid::SEPARATOR, $serialization, 2 );
 
 		if ( count( $keyParts ) !== 2 ) {
 			throw new StatementGuidParsingException( '$serialization does not have the correct number of parts' );

--- a/tests/unit/Statement/StatementGuidParserTest.php
+++ b/tests/unit/Statement/StatementGuidParserTest.php
@@ -3,9 +3,9 @@
 namespace Wikibase\DataModel\Services\Tests\Statement;
 
 use Wikibase\DataModel\Entity\BasicEntityIdParser;
-use Wikibase\DataModel\Statement\StatementGuid;
-use Wikibase\DataModel\Services\Statement\StatementGuidParser;
 use Wikibase\DataModel\Entity\ItemId;
+use Wikibase\DataModel\Services\Statement\StatementGuidParser;
+use Wikibase\DataModel\Statement\StatementGuid;
 
 /**
  * @covers Wikibase\DataModel\Services\Statement\StatementGuidParser
@@ -33,6 +33,8 @@ class StatementGuidParserTest extends \PHPUnit_Framework_TestCase {
 			array( new StatementGuid( new ItemId( 'q42' ), 'D8404CDA-25E4-4334-AF13-A3290BCD9C0N' ) ),
 			array( new StatementGuid( new ItemId( 'Q1234567' ), 'D4FDE516-F20C-4154-ADCE-7C5B609DFDFF' ) ),
 			array( new StatementGuid( new ItemId( 'Q1' ), 'foo' ) ),
+			array( new StatementGuid( new ItemId( 'Q1' ), '$' ) ),
+			array( new StatementGuid( new ItemId( 'Q1' ), '' ) ),
 		);
 	}
 
@@ -54,6 +56,7 @@ class StatementGuidParserTest extends \PHPUnit_Framework_TestCase {
 			array( 'q0' ),
 			array( '1p' ),
 			array( 'Q0$5627445f-43cb-ed6d-3adb-760e85bd17ee' ),
+			array( 'Q1' ),
 		);
 	}
 


### PR DESCRIPTION
There never was a test for a statement id with more than one dollar sign. Neither a positive nor a negative test. Therefore I consider this a bug. It's allowed to create a statement id "Q1$$" (where the first dollar sign is the separator), so it should be possible to parse this.
