### PR TITLE
Unify duplicate getSiteLinksInDiffFormat methods

### DIFF
--- a/src/Diff/Internal/SiteLinkListPatcher.php
+++ b/src/Diff/Internal/SiteLinkListPatcher.php
@@ -7,7 +7,6 @@ use Diff\Patcher\ListPatcher;
 use Diff\Patcher\MapPatcher;
 use InvalidArgumentException;
 use Wikibase\DataModel\Entity\ItemId;
-use Wikibase\DataModel\SiteLink;
 use Wikibase\DataModel\SiteLinkList;
 
 /**
@@ -75,10 +74,7 @@ class SiteLinkListPatcher {
 	private function getSiteLinksInDiffFormat( SiteLinkList $siteLinks ) {
 		$linksInDiffFormat = array();
 
-		/**
-		 * @var SiteLink $siteLink
-		 */
-		foreach ( $siteLinks as $siteLink ) {
+		foreach ( $siteLinks->toArray() as $siteLink ) {
 			$linksInDiffFormat[$siteLink->getSiteId()] = array(
 				'name' => $siteLink->getPageName(),
 				'badges' => array_map(

--- a/src/Diff/ItemDiffer.php
+++ b/src/Diff/ItemDiffer.php
@@ -8,7 +8,7 @@ use Wikibase\DataModel\Entity\EntityDocument;
 use Wikibase\DataModel\Entity\Item;
 use Wikibase\DataModel\Entity\ItemId;
 use Wikibase\DataModel\Services\Diff\Internal\StatementListDiffer;
-use Wikibase\DataModel\SiteLink;
+use Wikibase\DataModel\SiteLinkList;
 
 /**
  * @since 1.0
@@ -79,19 +79,16 @@ class ItemDiffer implements EntityDifferStrategy {
 		$array['aliases'] = $item->getFingerprint()->getAliasGroups()->toTextArray();
 		$array['label'] = $item->getFingerprint()->getLabels()->toTextArray();
 		$array['description'] = $item->getFingerprint()->getDescriptions()->toTextArray();
-		$array['links'] = $this->getLinksInDiffFormat( $item );
+		$array['links'] = $this->getSiteLinksInDiffFormat( $item->getSiteLinkList() );
 
 		return $array;
 	}
 
-	private function getLinksInDiffFormat( Item $item ) {
-		$links = array();
+	private function getSiteLinksInDiffFormat( SiteLinkList $siteLinks ) {
+		$linksInDiffFormat = array();
 
-		/**
-		 * @var SiteLink $siteLink
-		 */
-		foreach ( $item->getSiteLinkList() as $siteLink ) {
-			$links[$siteLink->getSiteId()] = array(
+		foreach ( $siteLinks->toArray() as $siteLink ) {
+			$linksInDiffFormat[$siteLink->getSiteId()] = array(
 				'name' => $siteLink->getPageName(),
 				'badges' => array_map(
 					function( ItemId $id ) {
@@ -102,7 +99,7 @@ class ItemDiffer implements EntityDifferStrategy {
 			);
 		}
 
-		return $links;
+		return $linksInDiffFormat;
 	}
 
 	/**


### PR DESCRIPTION
This patch:
- Narrows an interface from Item to SiteLinkList.
- Makes use of toArray.
- Renames methods and variables to make the two implementations much more identical. This is duplicate code, but I do not think we must get rid of this. But I find it helpful when it's a bit more obvious what's going on (think of a fulltext search for "getSiteLinksInDiffFormat").
