### PR TITLE
Add a lot of missing tests and test cases

### DIFF
--- a/src/Entity/NullEntityPrefetcher.php
+++ b/src/Entity/NullEntityPrefetcher.php
@@ -11,6 +11,8 @@ use Wikibase\DataModel\Entity\EntityId;
  *
  * @license GNU GPL v2+
  * @author Marius Hoch < hoo@online.de >
+ *
+ * @codeCoverageIgnore
  */
 class NullEntityPrefetcher implements EntityPrefetcher {
 

--- a/tests/unit/Diff/EntityDiffTest.php
+++ b/tests/unit/Diff/EntityDiffTest.php
@@ -6,6 +6,7 @@ use Diff\DiffOp\Diff\Diff;
 use Diff\DiffOp\DiffOpAdd;
 use Diff\DiffOp\DiffOpChange;
 use Diff\DiffOp\DiffOpRemove;
+use PHPUnit_Framework_TestCase;
 use Wikibase\DataModel\Services\Diff\EntityDiff;
 use Wikibase\DataModel\Services\Diff\Internal\StatementListDiffer;
 use Wikibase\DataModel\Snak\PropertyNoValueSnak;
@@ -18,7 +19,22 @@ use Wikibase\DataModel\Statement\StatementList;
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-class EntityDiffTest extends \PHPUnit_Framework_TestCase {
+class EntityDiffTest extends PHPUnit_Framework_TestCase {
+
+	/**
+	 * @dataProvider newForTypeProvider
+	 */
+	public function testNewForType( $entityType, $expected ) {
+		$diff = EntityDiff::newForType( $entityType );
+		$this->assertInstanceOf( $expected, $diff );
+	}
+
+	public function newForTypeProvider() {
+		return array(
+			array( 'item', 'Wikibase\DataModel\Services\Diff\ItemDiff' ),
+			array( 'anything', 'Wikibase\DataModel\Services\Diff\EntityDiff' ),
+		);
+	}
 
 	public function isEmptyProvider() {
 		$argLists = array();
@@ -149,6 +165,11 @@ class EntityDiffTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertInstanceOf( 'Diff\Diff', $diff );
 		$this->assertTrue( $diff->isAssociative() );
+	}
+
+	public function testGetType() {
+		$diff = new EntityDiff();
+		$this->assertSame( 'diff/entity', $diff->getType() );
 	}
 
 }

--- a/tests/unit/Lookup/EntityRedirectLookupExceptionTest.php
+++ b/tests/unit/Lookup/EntityRedirectLookupExceptionTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Tests\Lookup;
+
+use Exception;
+use PHPUnit_Framework_TestCase;
+use Wikibase\DataModel\Entity\ItemId;
+use Wikibase\DataModel\Services\Lookup\EntityRedirectLookupException;
+
+/**
+ * @covers Wikibase\DataModel\Services\Lookup\EntityRedirectLookupException
+ *
+ * @licence GNU GPL v2+
+ * @author Thiemo Mättig
+ */
+class EntityRedirectLookupExceptionTest extends PHPUnit_Framework_TestCase {
+
+	public function testConstructorWithOnlyRequiredArguments() {
+		$entityId = new ItemId( 'Q1' );
+		$exception = new EntityRedirectLookupException( $entityId );
+
+		$this->assertSame( $entityId, $exception->getEntityId() );
+		$this->assertSame( 'Entity redirect lookup failed for: Q1', $exception->getMessage() );
+		$this->assertSame( 0, $exception->getCode() );
+		$this->assertNull( $exception->getPrevious() );
+	}
+
+	public function testConstructorWithAllArguments() {
+		$entityId = new ItemId( 'Q1' );
+		$previous = new Exception( 'previous' );
+		$exception = new EntityRedirectLookupException( $entityId, 'customMessage', $previous );
+
+		$this->assertSame( $entityId, $exception->getEntityId() );
+		$this->assertSame( 'customMessage', $exception->getMessage() );
+		$this->assertSame( 0, $exception->getCode() );
+		$this->assertSame( $previous, $exception->getPrevious() );
+	}
+
+}

--- a/tests/unit/Lookup/LabelDescriptionLookupExceptionTest.php
+++ b/tests/unit/Lookup/LabelDescriptionLookupExceptionTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Tests\Lookup;
+
+use Exception;
+use PHPUnit_Framework_TestCase;
+use Wikibase\DataModel\Entity\ItemId;
+use Wikibase\DataModel\Services\Lookup\LabelDescriptionLookupException;
+
+/**
+ * @covers Wikibase\DataModel\Services\Lookup\LabelDescriptionLookupException
+ *
+ * @licence GNU GPL v2+
+ * @author Thiemo Mättig
+ */
+class LabelDescriptionLookupExceptionTest extends PHPUnit_Framework_TestCase {
+
+	public function testConstructorWithOnlyRequiredArguments() {
+		$itemId = new ItemId( 'Q1' );
+		$exception = new LabelDescriptionLookupException( $itemId );
+
+		$this->assertSame( $itemId, $exception->getEntityId() );
+		$this->assertSame( 'Label and description lookup failed for: Q1', $exception->getMessage() );
+		$this->assertSame( 0, $exception->getCode() );
+		$this->assertNull( $exception->getPrevious() );
+	}
+
+	public function testConstructorWithAllArguments() {
+		$itemId = new ItemId( 'Q1' );
+		$previous = new Exception( 'previous' );
+		$exception = new LabelDescriptionLookupException( $itemId, 'customMessage', $previous );
+
+		$this->assertSame( $itemId, $exception->getEntityId() );
+		$this->assertSame( 'customMessage', $exception->getMessage() );
+		$this->assertSame( 0, $exception->getCode() );
+		$this->assertSame( $previous, $exception->getPrevious() );
+	}
+
+}

--- a/tests/unit/Lookup/PropertyDataTypeLookupExceptionTest.php
+++ b/tests/unit/Lookup/PropertyDataTypeLookupExceptionTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Tests\Lookup;
+
+use Exception;
+use PHPUnit_Framework_TestCase;
+use Wikibase\DataModel\Entity\PropertyId;
+use Wikibase\DataModel\Services\Lookup\PropertyDataTypeLookupException;
+
+/**
+ * @covers Wikibase\DataModel\Services\Lookup\PropertyDataTypeLookupException
+ *
+ * @licence GNU GPL v2+
+ * @author Thiemo Mättig
+ */
+class PropertyDataTypeLookupExceptionTest extends PHPUnit_Framework_TestCase {
+
+	public function testConstructorWithOnlyRequiredArguments() {
+		$propertyId = new PropertyId( 'P1' );
+		$exception = new PropertyDataTypeLookupException( $propertyId );
+
+		$this->assertSame( $propertyId, $exception->getPropertyId() );
+		$this->assertSame( 'Property data type lookup failed for: P1', $exception->getMessage() );
+		$this->assertSame( 0, $exception->getCode() );
+		$this->assertNull( $exception->getPrevious() );
+	}
+
+	public function testConstructorWithAllArguments() {
+		$propertyId = new PropertyId( 'P1' );
+		$previous = new Exception( 'previous' );
+		$exception = new PropertyDataTypeLookupException( $propertyId, 'customMessage', $previous );
+
+		$this->assertSame( $propertyId, $exception->getPropertyId() );
+		$this->assertSame( 'customMessage', $exception->getMessage() );
+		$this->assertSame( 0, $exception->getCode() );
+		$this->assertSame( $previous, $exception->getPrevious() );
+	}
+
+}

--- a/tests/unit/Lookup/TermLookupExceptionTest.php
+++ b/tests/unit/Lookup/TermLookupExceptionTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Tests\Lookup;
+
+use Exception;
+use PHPUnit_Framework_TestCase;
+use Wikibase\DataModel\Entity\ItemId;
+use Wikibase\DataModel\Services\Lookup\TermLookupException;
+
+/**
+ * @covers Wikibase\DataModel\Services\Lookup\TermLookupException
+ *
+ * @licence GNU GPL v2+
+ * @author Thiemo Mättig
+ */
+class TermLookupExceptionTest extends PHPUnit_Framework_TestCase {
+
+	public function testConstructorWithOnlyRequiredArguments() {
+		$entityId = new ItemId( 'Q1' );
+		$exception = new TermLookupException( $entityId, array( 'de', 'en' ) );
+
+		$this->assertSame( $entityId, $exception->getEntityId() );
+		$this->assertSame(
+			'Term lookup failed for: Q1 with language codes: de, en',
+			$exception->getMessage()
+		);
+		$this->assertSame( 0, $exception->getCode() );
+		$this->assertNull( $exception->getPrevious() );
+	}
+
+	public function testConstructorWithAllArguments() {
+		$entityId = new ItemId( 'Q1' );
+		$previous = new Exception( 'previous' );
+		$exception = new TermLookupException(
+			$entityId,
+			array( 'de', 'en' ),
+			'customMessage',
+			$previous
+		);
+
+		$this->assertSame( $entityId, $exception->getEntityId() );
+		$this->assertSame( 'customMessage', $exception->getMessage() );
+		$this->assertSame( 0, $exception->getCode() );
+		$this->assertSame( $previous, $exception->getPrevious() );
+	}
+
+}

--- a/tests/unit/Lookup/UnresolvedEntityRedirectExceptionTest.php
+++ b/tests/unit/Lookup/UnresolvedEntityRedirectExceptionTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Tests\Lookup;
+
+use Exception;
+use PHPUnit_Framework_TestCase;
+use Wikibase\DataModel\Entity\ItemId;
+use Wikibase\DataModel\Services\Lookup\UnresolvedEntityRedirectException;
+
+/**
+ * @covers Wikibase\DataModel\Services\Lookup\UnresolvedEntityRedirectException
+ *
+ * @licence GNU GPL v2+
+ * @author Thiemo Mättig
+ */
+class UnresolvedEntityRedirectExceptionTest extends PHPUnit_Framework_TestCase {
+
+	public function testConstructorWithOnlyRequiredArguments() {
+		$entityId = new ItemId( 'Q1' );
+		$redirectTargetId = new ItemId( 'Q2' );
+		$exception = new UnresolvedEntityRedirectException( $entityId, $redirectTargetId );
+
+		$this->assertSame( $entityId, $exception->getEntityId() );
+		$this->assertSame( $redirectTargetId, $exception->getRedirectTargetId() );
+		$this->assertSame( 'Unresolved redirect to Q2', $exception->getMessage() );
+		$this->assertSame( 0, $exception->getCode() );
+		$this->assertNull( $exception->getPrevious() );
+	}
+
+	public function testConstructorWithAllArguments() {
+		$entityId = new ItemId( 'Q1' );
+		$redirectTargetId = new ItemId( 'Q2' );
+		$previous = new Exception( 'previous' );
+		$exception = new UnresolvedEntityRedirectException(
+			$entityId,
+			$redirectTargetId,
+			'customMessage',
+			$previous
+		);
+
+		$this->assertSame( $entityId, $exception->getEntityId() );
+		$this->assertSame( $redirectTargetId, $exception->getRedirectTargetId() );
+		$this->assertSame( 'customMessage', $exception->getMessage() );
+		$this->assertSame( 0, $exception->getCode() );
+		$this->assertSame( $previous, $exception->getPrevious() );
+	}
+
+}


### PR DESCRIPTION
This raises code coverage in this component to a total of 96% per line (76% per class).

In this patch I focused on easy picks. There are still some lines left to test, but they are all edge cases and conditions that are not so easy to test. The remaining "Top Project Risk" according to PHPUnit's CRAP factor based ranking is `EntityDiff::fixSubstructureDiff`.
