### PR TITLE
Release 3.3.0

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,6 +1,6 @@
 # Wikibase DataModel Services release notes
 
-## Version 3.3.0 (2016-02-16)
+## Version 3.3.0 (2016-02-18)
 
 * Added compatibility with Wikibase DataModel 5.0.
 * Added `FILTER_TYPE` constant to `DataTypeStatementFilter`, `NullStatementFilter` and `PropertySetStatementFilter`.

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -4,6 +4,7 @@
 
 * Added compatibility with Wikibase DataModel 5.0.
 * Added `FILTER_TYPE` constant to `DataTypeStatementFilter`, `NullStatementFilter` and `PropertySetStatementFilter`.
+* Fixed `StatementGuidParser` not parsing GUIDs with multiple dollar signs.
 
 ## Version 3.2.0 (2015-12-03)
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,7 +1,8 @@
 # Wikibase DataModel Services release notes
 
-## Version 3.3.0 (dev)
+## Version 3.3.0 (2016-02-16)
 
+* Added compatibility with Wikibase DataModel 5.0.
 * Added `FILTER_TYPE` constant to `DataTypeStatementFilter`, `NullStatementFilter` and `PropertySetStatementFilter`.
 
 ## Version 3.2.0 (2015-12-03)

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 	},
 	"require": {
 		"php": ">=5.3.0",
-		"wikibase/data-model": "~4.2",
+		"wikibase/data-model": "~5.0|~4.2",
 		"data-values/data-values": "~0.1|~1.0",
 		"diff/diff": "~2.0|~1.0"
 	},

--- a/tests/fixtures/EntityOfUnknownType.php
+++ b/tests/fixtures/EntityOfUnknownType.php
@@ -34,4 +34,28 @@ class EntityOfUnknownType implements EntityDocument {
 		return true;
 	}
 
+	/**
+	 * @see EntityDocument::equals
+	 *
+	 * @since 3.3
+	 *
+	 * @param mixed $target
+	 *
+	 * @return bool Always true.
+	 */
+	public function equals( $target ) {
+		return true;
+	}
+
+	/**
+	 * @see EntityDocument::copy
+	 *
+	 * @since 3.3
+	 *
+	 * @return self
+	 */
+	public function copy() {
+		return $this;
+	}
+
 }

--- a/tests/fixtures/FakeEntityDocument.php
+++ b/tests/fixtures/FakeEntityDocument.php
@@ -51,4 +51,28 @@ class FakeEntityDocument implements EntityDocument {
 		return true;
 	}
 
+	/**
+	 * @see EntityDocument::equals
+	 *
+	 * @since 3.3
+	 *
+	 * @param mixed $target
+	 *
+	 * @return bool Always true.
+	 */
+	public function equals( $target ) {
+		return true;
+	}
+
+	/**
+	 * @see EntityDocument::copy
+	 *
+	 * @since 3.3
+	 *
+	 * @return self
+	 */
+	public function copy() {
+		return new self( $this->id );
+	}
+
 }


### PR DESCRIPTION
There is currently not much in this release, see https://github.com/wmde/WikibaseDataModelServices/compare/3.2.0...master. Please have a look at the open pull requests before tagging a release. I added some to the 3.3.0 milestone, but we may want to merge some more that are currently not in the milestone. Please talk to me if you are not sure.

Would be cool to release this today.
