### PR TITLE
Introduce RestrictedEntityLookup::reset

### DIFF
--- a/src/Lookup/RestrictedEntityLookup.php
+++ b/src/Lookup/RestrictedEntityLookup.php
@@ -105,12 +105,13 @@ class RestrictedEntityLookup implements EntityLookup {
 	}
 
 	/**
-	 * Resets the number of entities loaded via this object.
+	 * Resets the number and list of entities loaded via this object.
 	 *
 	 * @since 3.4
 	 */
-	public function resetEntityAccessCount() {
+	public function reset() {
 		$this->entityAccessCount = 0;
+		$this->entitiesAccessed = array();
 	}
 
 	/**

--- a/tests/unit/Lookup/RestrictedEntityLookupTest.php
+++ b/tests/unit/Lookup/RestrictedEntityLookupTest.php
@@ -67,14 +67,18 @@ class RestrictedEntityLookupTest extends \PHPUnit_Framework_TestCase {
 		$this->assertSame( 5, $lookup->getEntityAccessCount() );
 	}
 
-	public function testResetEntityAccessCount() {
+	public function testReset() {
 		$lookup = new RestrictedEntityLookup( $this->getEntityLookup(), 200 );
 		$lookup->getEntity( new ItemId( 'Q1' ) );
 
-		$lookup->resetEntityAccessCount();
+		$lookup->reset();
 
 		$lookup->getEntity( new ItemId( 'Q2' ) );
 		$this->assertSame( 1, $lookup->getEntityAccessCount() );
+
+		// An entity accessed before, but after reset counts again
+		$lookup->getEntity( new ItemId( 'Q1' ) );
+		$this->assertSame( 2, $lookup->getEntityAccessCount() );
 	}
 
 	public function testGetEntity() {


### PR DESCRIPTION
And remove the reset access count method, as that didn't reset the list of entities loaded, thus serves no real purpose.

[Bug: T127462](http://phabricator.wikimedia.org/T127462)
