### PR TITLE
Introduce TermListPatcher and AliasGroupListPatcher

### DIFF
--- a/src/Diff/Internal/AliasGroupListPatcher.php
+++ b/src/Diff/Internal/AliasGroupListPatcher.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Diff\Internal;
+
+use Diff\DiffOp\Diff\Diff;
+use Diff\DiffOp\DiffOp;
+use Diff\DiffOp\DiffOpAdd;
+use Diff\DiffOp\DiffOpChange;
+use Diff\DiffOp\DiffOpRemove;
+use Diff\Patcher\MapPatcher;
+use Diff\Patcher\PatcherException;
+use Wikibase\DataModel\Term\AliasGroupList;
+
+/**
+ * Package private.
+ *
+ * @since 3.6
+ *
+ * @license GPL-2.0+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ * @author Thiemo Mättig
+ */
+class AliasGroupListPatcher {
+
+	/**
+	 * @since 3.6
+	 *
+	 * @param AliasGroupList $groups
+	 * @param Diff $patch
+	 *
+	 * @throws PatcherException
+	 */
+	public function patchAliasGroupList( AliasGroupList $groups, Diff $patch ) {
+		foreach ( $patch as $lang => $diffOp ) {
+			$this->patchAliasGroup( $groups, $lang, $diffOp );
+		}
+	}
+
+	/**
+	 * @see MapPatcher
+	 *
+	 * @param AliasGroupList $groups
+	 * @param string $lang
+	 * @param DiffOp $diffOp
+	 *
+	 * @throws PatcherException
+	 */
+	private function patchAliasGroup( AliasGroupList $groups, $lang, DiffOp $diffOp ) {
+		$hasLang = $groups->hasGroupForLanguage( $lang );
+
+		switch ( true ) {
+			case $diffOp instanceof DiffOpAdd:
+				/** @var $diffOp DiffOpAdd */
+				if ( !$hasLang ) {
+					$groups->setAliasesForLanguage( $lang, $diffOp->getNewValue() );
+				}
+				break;
+
+			case $diffOp instanceof DiffOpChange:
+				/** @var $diffOp DiffOpChange */
+				$this->applyAliasGroupChange( $groups, $lang, $diffOp );
+				break;
+
+			case $diffOp instanceof DiffOpRemove:
+				/** @var $diffOp DiffOpRemove */
+				if ( $hasLang
+					&& $groups->getByLanguage( $lang )->getAliases() === $diffOp->getOldValue()
+				) {
+					$groups->removeByLanguage( $lang );
+				}
+				break;
+
+			case $diffOp instanceof Diff:
+				/** @var $diffOp Diff */
+				$this->applyAliasGroupDiff( $groups, $lang, $diffOp );
+				break;
+
+			default:
+				throw new PatcherException( 'Invalid aliases diff' );
+		}
+	}
+
+	/**
+	 * @param AliasGroupList $groups
+	 * @param string $lang
+	 * @param DiffOpChange $patch
+	 */
+	private function applyAliasGroupChange( AliasGroupList $groups, $lang, DiffOpChange $patch ) {
+		if ( $groups->hasGroupForLanguage( $lang )
+			&& $groups->getByLanguage( $lang )->getAliases() === $patch->getOldValue()
+		) {
+			$groups->setAliasesForLanguage( $lang, $patch->getNewValue() );
+		}
+	}
+
+	/**
+	 * @param AliasGroupList $groups
+	 * @param string $lang
+	 * @param Diff $patch
+	 */
+	private function applyAliasGroupDiff( AliasGroupList $groups, $lang, Diff $patch ) {
+		$hasLang = $groups->hasGroupForLanguage( $lang );
+
+		if ( $hasLang || !$this->containsOperationsOnOldValues( $patch ) ) {
+			$aliases = $hasLang ? $groups->getByLanguage( $lang )->getAliases() : array();
+			$aliases = $this->getPatchedAliases( $aliases, $patch );
+			$groups->setAliasesForLanguage( $lang, $aliases );
+		}
+	}
+
+	/**
+	 * @param Diff $diff
+	 *
+	 * @return bool
+	 */
+	private function containsOperationsOnOldValues( Diff $diff ) {
+		return $diff->getChanges() !== array()
+			|| $diff->getRemovals() !== array();
+	}
+
+	/**
+	 * @see ListPatcher
+	 *
+	 * @param string[] $aliases
+	 * @param Diff $patch
+	 *
+	 * @throws PatcherException
+	 * @return string[]
+	 */
+	private function getPatchedAliases( array $aliases, Diff $patch ) {
+		foreach ( $patch as $diffOp ) {
+			switch ( true ) {
+				case $diffOp instanceof DiffOpAdd:
+					/** @var $diffOp DiffOpAdd */
+					$aliases[] = $diffOp->getNewValue();
+					break;
+
+				case $diffOp instanceof DiffOpChange:
+					/** @var $diffOp DiffOpChange */
+					$key = array_search( $diffOp->getOldValue(), $aliases, true );
+					if ( $key !== false ) {
+						unset( $aliases[$key] );
+						$aliases[] = $diffOp->getNewValue();
+					}
+					break;
+
+				case $diffOp instanceof DiffOpRemove:
+					/** @var $diffOp DiffOpRemove */
+					$key = array_search( $diffOp->getOldValue(), $aliases, true );
+					if ( $key !== false ) {
+						unset( $aliases[$key] );
+					}
+					break;
+
+				default:
+					throw new PatcherException( 'Invalid aliases diff' );
+			}
+		}
+
+		return $aliases;
+	}
+
+}

--- a/src/Diff/Internal/FingerprintPatcher.php
+++ b/src/Diff/Internal/FingerprintPatcher.php
@@ -2,24 +2,17 @@
 
 namespace Wikibase\DataModel\Services\Diff\Internal;
 
-use Diff\DiffOp\AtomicDiffOp;
-use Diff\DiffOp\Diff\Diff;
-use Diff\DiffOp\DiffOp;
-use Diff\DiffOp\DiffOpAdd;
-use Diff\DiffOp\DiffOpChange;
-use Diff\DiffOp\DiffOpRemove;
-use Diff\Patcher\MapPatcher;
 use Diff\Patcher\PatcherException;
 use Wikibase\DataModel\Services\Diff\EntityDiff;
-use Wikibase\DataModel\Term\AliasGroupList;
 use Wikibase\DataModel\Term\Fingerprint;
-use Wikibase\DataModel\Term\TermList;
 
 /**
- * TODO: Class should be public (or split, and these should be public).
+ * TODO: Class should be public.
  * TODO: Should this support actual edit conflict detection?
  *
  * Package private.
+ *
+ * @since 1.0
  *
  * @license GPL-2.0+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
@@ -28,209 +21,43 @@ use Wikibase\DataModel\Term\TermList;
 class FingerprintPatcher {
 
 	/**
+	 * @var TermListPatcher
+	 */
+	private $termListPatcher;
+
+	/**
+	 * @var AliasGroupListPatcher
+	 */
+	private $aliasGroupListPatcher;
+
+	public function __construct() {
+		$this->termListPatcher = new TermListPatcher();
+		$this->aliasGroupListPatcher = new AliasGroupListPatcher();
+	}
+
+	/**
+	 * @since 1.0
+	 *
 	 * @param Fingerprint $fingerprint
 	 * @param EntityDiff $patch
 	 *
 	 * @throws PatcherException
 	 */
 	public function patchFingerprint( Fingerprint $fingerprint, EntityDiff $patch ) {
-		$this->patchTermList( $fingerprint->getLabels(), $patch->getLabelsDiff() );
-		$this->patchTermList( $fingerprint->getDescriptions(), $patch->getDescriptionsDiff() );
+		$this->termListPatcher->patchTermList(
+			$fingerprint->getLabels(),
+			$patch->getLabelsDiff()
+		);
 
-		$this->patchAliasGroupList( $fingerprint->getAliasGroups(), $patch->getAliasesDiff() );
-	}
+		$this->termListPatcher->patchTermList(
+			$fingerprint->getDescriptions(),
+			$patch->getDescriptionsDiff()
+		);
 
-	/**
-	 * @param TermList $terms
-	 * @param Diff $patch
-	 *
-	 * @throws PatcherException
-	 */
-	private function patchTermList( TermList $terms, Diff $patch ) {
-		foreach ( $patch as $lang => $diffOp ) {
-			$this->patchTerm( $terms, $lang, $diffOp );
-		}
-	}
-
-	/**
-	 * @see MapPatcher
-	 *
-	 * @param TermList $terms
-	 * @param string $lang
-	 * @param AtomicDiffOp $diffOp
-	 *
-	 * @throws PatcherException
-	 */
-	private function patchTerm( TermList $terms, $lang, AtomicDiffOp $diffOp ) {
-		$hasLang = $terms->hasTermForLanguage( $lang );
-
-		switch ( true ) {
-			case $diffOp instanceof DiffOpAdd:
-				/** @var DiffOpAdd $diffOp */
-				if ( !$hasLang ) {
-					$terms->setTextForLanguage( $lang, $diffOp->getNewValue() );
-				}
-				break;
-
-			case $diffOp instanceof DiffOpChange:
-				/** @var DiffOpChange $diffOp */
-				if ( $hasLang
-					&& $terms->getByLanguage( $lang )->getText() === $diffOp->getOldValue()
-				) {
-					$terms->setTextForLanguage( $lang, $diffOp->getNewValue() );
-				}
-				break;
-
-			case $diffOp instanceof DiffOpRemove:
-				/** @var DiffOpRemove $diffOp */
-				if ( $hasLang
-					&& $terms->getByLanguage( $lang )->getText() === $diffOp->getOldValue()
-				) {
-					$terms->removeByLanguage( $lang );
-				}
-				break;
-
-			default:
-				throw new PatcherException( 'Invalid terms diff' );
-		}
-	}
-
-	/**
-	 * @param AliasGroupList $groups
-	 * @param Diff $patch
-	 *
-	 * @throws PatcherException
-	 */
-	private function patchAliasGroupList( AliasGroupList $groups, Diff $patch ) {
-		foreach ( $patch as $lang => $diffOp ) {
-			$this->patchAliasGroup( $groups, $lang, $diffOp );
-		}
-	}
-
-	/**
-	 * @see MapPatcher
-	 *
-	 * @param AliasGroupList $groups
-	 * @param string $lang
-	 * @param DiffOp $diffOp
-	 *
-	 * @throws PatcherException
-	 */
-	private function patchAliasGroup( AliasGroupList $groups, $lang, DiffOp $diffOp ) {
-		$hasLang = $groups->hasGroupForLanguage( $lang );
-
-		switch ( true ) {
-			case $diffOp instanceof DiffOpAdd:
-				/** @var DiffOpAdd $diffOp */
-				if ( !$hasLang ) {
-					$groups->setAliasesForLanguage( $lang, $diffOp->getNewValue() );
-				}
-				break;
-
-			case $diffOp instanceof DiffOpChange:
-				/** @var DiffOpChange $diffOp */
-				$this->applyAliasGroupChange( $groups, $lang, $diffOp );
-				break;
-
-			case $diffOp instanceof DiffOpRemove:
-				/** @var DiffOpRemove $diffOp */
-				if ( $hasLang
-					&& $groups->getByLanguage( $lang )->getAliases() === $diffOp->getOldValue()
-				) {
-					$groups->removeByLanguage( $lang );
-				}
-				break;
-
-			case $diffOp instanceof Diff:
-				$this->applyAliasGroupDiff( $groups, $lang, $diffOp );
-				break;
-
-			default:
-				throw new PatcherException( 'Invalid aliases diff' );
-		}
-	}
-
-	/**
-	 * @param AliasGroupList $groups
-	 * @param string $lang
-	 * @param DiffOpChange $patch
-	 */
-	private function applyAliasGroupChange( AliasGroupList $groups, $lang, DiffOpChange $patch ) {
-		if ( $groups->hasGroupForLanguage( $lang )
-			&& $groups->getByLanguage( $lang )->getAliases() === $patch->getOldValue()
-		) {
-			$groups->setAliasesForLanguage( $lang, $patch->getNewValue() );
-		}
-	}
-
-	/**
-	 * @param AliasGroupList $groups
-	 * @param string $lang
-	 * @param Diff $patch
-	 */
-	private function applyAliasGroupDiff( AliasGroupList $groups, $lang, Diff $patch ) {
-		$hasLang = $groups->hasGroupForLanguage( $lang );
-
-		if ( $hasLang || !$this->containsOperationsOnOldValues( $patch ) ) {
-			$aliases = $hasLang ? $groups->getByLanguage( $lang )->getAliases() : array();
-			$aliases = $this->getPatchedAliases( $aliases, $patch );
-			$groups->setAliasesForLanguage( $lang, $aliases );
-		}
-	}
-
-	/**
-	 * @param Diff $diff
-	 *
-	 * @return bool
-	 */
-	private function containsOperationsOnOldValues( Diff $diff ) {
-		return $diff->getChanges() !== array()
-			|| $diff->getRemovals() !== array();
-	}
-
-	/**
-	 * @see ListPatcher
-	 *
-	 * @param string[] $aliases
-	 * @param Diff $patch
-	 *
-	 * @throws PatcherException
-	 * @return string[]
-	 */
-	private function getPatchedAliases( array $aliases, Diff $patch ) {
-		/** @var DiffOp $diffOp */
-		foreach ( $patch as $diffOp ) {
-			switch ( true ) {
-				case $diffOp instanceof DiffOpAdd:
-					/** @var DiffOpAdd $diffOp */
-					$aliases[] = $diffOp->getNewValue();
-					break;
-
-				case $diffOp instanceof DiffOpChange:
-					/** @var DiffOpChange $diffOp */
-					$key = array_search( $diffOp->getOldValue(), $aliases, true );
-
-					if ( $key !== false ) {
-						unset( $aliases[$key] );
-						$aliases[] = $diffOp->getNewValue();
-					}
-					break;
-
-				case $diffOp instanceof DiffOpRemove:
-					/** @var DiffOpRemove $diffOp */
-					$key = array_search( $diffOp->getOldValue(), $aliases, true );
-
-					if ( $key !== false ) {
-						unset( $aliases[$key] );
-					}
-					break;
-
-				default:
-					throw new PatcherException( 'Invalid aliases diff' );
-			}
-		}
-
-		return $aliases;
+		$this->aliasGroupListPatcher->patchAliasGroupList(
+			$fingerprint->getAliasGroups(),
+			$patch->getAliasesDiff()
+		);
 	}
 
 }

--- a/src/Diff/Internal/TermListPatcher.php
+++ b/src/Diff/Internal/TermListPatcher.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Diff\Internal;
+
+use Diff\DiffOp\AtomicDiffOp;
+use Diff\DiffOp\Diff\Diff;
+use Diff\DiffOp\DiffOpAdd;
+use Diff\DiffOp\DiffOpChange;
+use Diff\DiffOp\DiffOpRemove;
+use Diff\Patcher\PatcherException;
+use Wikibase\DataModel\Term\TermList;
+
+/**
+ * Package private.
+ *
+ * @since 3.6
+ *
+ * @license GPL-2.0+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ * @author Thiemo Mättig
+ */
+class TermListPatcher {
+
+	/**
+	 * @since 3.6
+	 *
+	 * @param TermList $terms
+	 * @param Diff $patch
+	 *
+	 * @throws PatcherException
+	 */
+	public function patchTermList( TermList $terms, Diff $patch ) {
+		foreach ( $patch as $lang => $diffOp ) {
+			$this->patchTerm( $terms, $lang, $diffOp );
+		}
+	}
+
+	/**
+	 * @see MapPatcher
+	 *
+	 * @param TermList $terms
+	 * @param string $lang
+	 * @param AtomicDiffOp $diffOp
+	 *
+	 * @throws PatcherException
+	 */
+	private function patchTerm( TermList $terms, $lang, AtomicDiffOp $diffOp ) {
+		$hasLang = $terms->hasTermForLanguage( $lang );
+
+		switch ( true ) {
+			case $diffOp instanceof DiffOpAdd:
+				/** @var $diffOp DiffOpAdd */
+				if ( !$hasLang ) {
+					$terms->setTextForLanguage( $lang, $diffOp->getNewValue() );
+				}
+				break;
+
+			case $diffOp instanceof DiffOpChange:
+				/** @var $diffOp DiffOpChange */
+				if ( $hasLang
+					&& $terms->getByLanguage( $lang )->getText() === $diffOp->getOldValue()
+				) {
+					$terms->setTextForLanguage( $lang, $diffOp->getNewValue() );
+				}
+				break;
+
+			case $diffOp instanceof DiffOpRemove:
+				/** @var $diffOp DiffOpRemove */
+				if ( $hasLang
+					&& $terms->getByLanguage( $lang )->getText() === $diffOp->getOldValue()
+				) {
+					$terms->removeByLanguage( $lang );
+				}
+				break;
+
+			default:
+				throw new PatcherException( 'Invalid terms diff' );
+		}
+	}
+
+}

--- a/tests/unit/Diff/Internal/AliasGroupListPatcherTest.php
+++ b/tests/unit/Diff/Internal/AliasGroupListPatcherTest.php
@@ -1,0 +1,250 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Tests\Diff\Internal;
+
+use Diff\DiffOp\Diff\Diff;
+use Diff\DiffOp\DiffOpAdd;
+use Diff\DiffOp\DiffOpChange;
+use Diff\DiffOp\DiffOpRemove;
+use PHPUnit_Framework_TestCase;
+use Wikibase\DataModel\Services\Diff\Internal\AliasGroupListPatcher;
+use Wikibase\DataModel\Term\AliasGroup;
+use Wikibase\DataModel\Term\AliasGroupList;
+
+/**
+ * @covers Wikibase\DataModel\Services\Diff\Internal\AliasGroupListPatcher
+ *
+ * @license GPL-2.0+
+ * @author Bene* < benestar.wikimedia@gmail.com >
+ */
+class AliasGroupListPatcherTest extends PHPUnit_Framework_TestCase {
+
+	/**
+	 * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+	 */
+	public function providePatchAliasGroupList() {
+		return array(
+			'add aliases (associative)' => array(
+				new AliasGroupList(),
+				new Diff( array(
+					'en' => new Diff( array( new DiffOpAdd( 'foo' ), new DiffOpAdd( 'bar' ) ) )
+				), true ),
+				new AliasGroupList( array(
+					new AliasGroup( 'en', array( 'foo', 'bar' ) )
+				) )
+			),
+			'add aliases (non-associative)' => array(
+				new AliasGroupList(),
+				new Diff( array(
+					'en' => new Diff( array( new DiffOpAdd( 'foo' ), new DiffOpAdd( 'bar' ) ) )
+				), false ),
+				new AliasGroupList( array(
+					new AliasGroup( 'en', array( 'foo', 'bar' ) )
+				) )
+			),
+			'add aliases (auto-detected)' => array(
+				new AliasGroupList(),
+				new Diff( array(
+					'en' => new Diff( array( new DiffOpAdd( 'foo' ), new DiffOpAdd( 'bar' ) ) )
+				) ),
+				new AliasGroupList( array(
+					new AliasGroup( 'en', array( 'foo', 'bar' ) )
+				) )
+			),
+			'add aliases (atomic)' => array(
+				new AliasGroupList(),
+				new Diff( array(
+					'en' => new DiffOpAdd( array( 'foo', 'bar' ) )
+				) ),
+				new AliasGroupList( array(
+					new AliasGroup( 'en', array( 'foo', 'bar' ) )
+				) )
+			),
+			'change aliase' => array(
+				new AliasGroupList( array(
+					new AliasGroup( 'en', array( 'foo', 'bar' ) )
+				) ),
+				new Diff( array(
+					'en' => new Diff( array( new DiffOpChange( 'bar', 'baz' ) ) )
+				) ),
+				new AliasGroupList( array(
+					new AliasGroup( 'en', array( 'foo', 'baz' ) )
+				) )
+			),
+			'change aliases (atomic)' => array(
+				new AliasGroupList( array(
+					new AliasGroup( 'en', array( 'foo', 'bar' ) )
+				) ),
+				new Diff( array(
+					'en' => new DiffOpChange( array( 'foo', 'bar' ), array( 'baz' ) )
+				) ),
+				new AliasGroupList( array(
+					new AliasGroup( 'en', array( 'baz' ) )
+				) )
+			),
+			'remove all aliases' => array(
+				new AliasGroupList( array(
+					new AliasGroup( 'en', array( 'foo', 'bar' ) )
+				) ),
+				new Diff( array(
+					'en' => new Diff( array( new DiffOpRemove( 'foo' ), new DiffOpRemove( 'bar' ) ) )
+				) ),
+				new AliasGroupList()
+			),
+			'remove all aliases (atomic)' => array(
+				new AliasGroupList( array(
+					new AliasGroup( 'en', array( 'foo', 'bar' ) )
+				) ),
+				new Diff( array(
+					'en' => new DiffOpRemove( array( 'foo', 'bar' ) )
+				) ),
+				new AliasGroupList()
+			),
+			'remove some aliases' => array(
+				new AliasGroupList( array(
+					new AliasGroup( 'en', array( 'foo', 'bar', 'baz' ) )
+				) ),
+				new Diff( array(
+					'en' => new Diff( array( new DiffOpRemove( 'foo' ), new DiffOpRemove( 'bar' ) ) )
+				) ),
+				new AliasGroupList( array(
+					new AliasGroup( 'en', array( 'baz' ) )
+				) )
+			),
+			'remove some aliases is no-op (atomic)' => array(
+				new AliasGroupList( array(
+					new AliasGroup( 'en', array( 'foo', 'bar', 'baz' ) )
+				) ),
+				new Diff( array(
+					'en' => new DiffOpRemove( array( 'foo', 'bar' ) )
+				) ),
+				new AliasGroupList( array(
+					new AliasGroup( 'en', array( 'foo', 'bar', 'baz' ) )
+				) )
+			),
+			'add alias to an existing language' => array(
+				new AliasGroupList( array(
+					new AliasGroup( 'en', array( 'foo', 'bar' ) )
+				) ),
+				new Diff( array(
+					'en' => new Diff( array( new DiffOpAdd( 'baz' ) ) )
+				) ),
+				new AliasGroupList( array(
+					new AliasGroup( 'en', array( 'foo', 'bar', 'baz' ) )
+				) )
+			),
+			'add an existing language is no-op (atomic)' => array(
+				new AliasGroupList( array(
+					new AliasGroup( 'en', array( 'foo', 'bar' ) )
+				) ),
+				new Diff( array(
+					'en' => new DiffOpAdd( array( 'baz' ) )
+				) ),
+				new AliasGroupList( array(
+					new AliasGroup( 'en', array( 'foo', 'bar' ) )
+				) )
+			),
+			'add two alias groups' => array(
+				new AliasGroupList( array(
+					new AliasGroup( 'en', array( 'foo', 'bar' ) )
+				) ),
+				new Diff( array(
+					'de' => new Diff( array( new DiffOpAdd( 'foo' ), new DiffOpAdd( 'baz' ) ) ),
+					'nl' => new Diff( array( new DiffOpAdd( 'bar' ), new DiffOpAdd( 'baz' ) ) )
+				) ),
+				new AliasGroupList( array(
+					new AliasGroup( 'en', array( 'foo', 'bar' ) ),
+					new AliasGroup( 'de', array( 'foo', 'baz' ) ),
+					new AliasGroup( 'nl', array( 'bar', 'baz' ) )
+				) )
+			),
+			'add two alias groups (atomic)' => array(
+				new AliasGroupList( array(
+					new AliasGroup( 'en', array( 'foo', 'bar' ) )
+				) ),
+				new Diff( array(
+					'de' => new DiffOpAdd( array( 'foo', 'baz' ) ),
+					'nl' => new DiffOpAdd( array( 'bar', 'baz' ) )
+				) ),
+				new AliasGroupList( array(
+					new AliasGroup( 'en', array( 'foo', 'bar' ) ),
+					new AliasGroup( 'de', array( 'foo', 'baz' ) ),
+					new AliasGroup( 'nl', array( 'bar', 'baz' ) )
+				) )
+			),
+			'remove a not existing language is no-op' => array(
+				new AliasGroupList( array(
+					new AliasGroup( 'en', array( 'foo', 'bar' ) )
+				) ),
+				new Diff( array(
+					'de' => new Diff( array( new DiffOpRemove( 'bar' ) ) )
+				) ),
+				new AliasGroupList( array(
+					new AliasGroup( 'en', array( 'foo', 'bar' ) )
+				) )
+			),
+			'remove a not existing language is no-op (atomic)' => array(
+				new AliasGroupList( array(
+					new AliasGroup( 'en', array( 'foo', 'bar' ) )
+				) ),
+				new Diff( array(
+					'de' => new DiffOpRemove( array( 'bar' ) )
+				) ),
+				new AliasGroupList( array(
+					new AliasGroup( 'en', array( 'foo', 'bar' ) )
+				) )
+			),
+			'change different aliases is no-op' => array(
+				new AliasGroupList( array(
+					new AliasGroup( 'en', array( 'foo' ) )
+				) ),
+				new Diff( array(
+					'en' => new Diff( array( new DiffOpChange( 'bar', 'baz' ) ) )
+				) ),
+				new AliasGroupList( array(
+					new AliasGroup( 'en', array( 'foo' ) )
+				) )
+			),
+			'change different aliases is no-op (atomic)' => array(
+				new AliasGroupList( array(
+					new AliasGroup( 'en', array( 'foo', 'bar' ) )
+				) ),
+				new Diff( array(
+					'en' => new DiffOpChange( array( 'foo', 'baz' ), array( 'baz' ) )
+				) ),
+				new AliasGroupList( array(
+					new AliasGroup( 'en', array( 'foo', 'bar' ) )
+				) )
+			),
+			'complex diff' => array(
+				new AliasGroupList( array(
+					new AliasGroup( 'en', array( 'foo', 'bar' ) ),
+					new AliasGroup( 'de', array( 'foo', 'baz' ) ),
+				    new AliasGroup( 'nl', array( 'bar', 'baz' ) )
+				) ),
+				new Diff( array(
+					'en' => new Diff( array( new DiffOpRemove( 'foo' ), new DiffOpAdd( 'baz' ) ) ),
+					'de' => new Diff( array( new DiffOpRemove( 'foo' ), new DiffOpRemove( 'baz' ) ) ),
+					'nl' => new Diff( array( new DiffOpRemove( 'foo' ), new DiffOpRemove( 'bar' ) ) ),
+					'it' => new Diff( array( new DiffOpAdd( 'bar' ), new DiffOpAdd( 'baz' ) ) )
+				) ),
+				new AliasGroupList( array(
+					new AliasGroup( 'en', array( 'bar', 'baz' ) ),
+					new AliasGroup( 'nl', array( 'baz' ) ),
+					new AliasGroup( 'it', array( 'bar', 'baz' ) )
+				) )
+			),
+		);
+	}
+
+	/**
+	 * @dataProvider providePatchAliasGroupList
+	 */
+	public function testPatchAliasGroupList( AliasGroupList $aliasGroups, Diff $patch, AliasGroupList $expected ) {
+		$patcher = new AliasGroupListPatcher();
+		$patcher->patchAliasGroupList( $aliasGroups, $patch );
+
+		$this->assertSame( $expected->toTextArray(), $aliasGroups->toTextArray() );
+	}
+
+}

--- a/tests/unit/Diff/Internal/TermListPatcherTest.php
+++ b/tests/unit/Diff/Internal/TermListPatcherTest.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Tests\Diff\Internal;
+
+use Diff\DiffOp\Diff\Diff;
+use Diff\DiffOp\DiffOpAdd;
+use Diff\DiffOp\DiffOpChange;
+use Diff\DiffOp\DiffOpRemove;
+use PHPUnit_Framework_TestCase;
+use Wikibase\DataModel\Services\Diff\Internal\TermListPatcher;
+use Wikibase\DataModel\Term\Term;
+use Wikibase\DataModel\Term\TermList;
+
+/**
+ * @covers Wikibase\DataModel\Services\Diff\Internal\TermListPatcher
+ *
+ * @license GPL-2.0+
+ * @author Bene* < benestar.wikimedia@gmail.com >
+ */
+class TermListPatcherTest extends PHPUnit_Framework_TestCase {
+
+	/**
+	 * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+	 */
+	public function providePatchTermList() {
+		return array(
+			'add a term' => array(
+				new TermList(),
+				new Diff( array(
+					'en' => new DiffOpAdd( 'foo' )
+				) ),
+				new TermList( array(
+					new Term( 'en', 'foo' )
+				) )
+			),
+			'change a term' => array(
+				new TermList( array(
+					new Term( 'en', 'foo' )
+				) ),
+				new Diff( array(
+					'en' => new DiffOpChange( 'foo', 'bar' )
+				) ),
+				new TermList( array(
+					new Term( 'en', 'bar' )
+				) )
+			),
+			'remove a term' => array(
+				new TermList( array(
+					new Term( 'en', 'foo' )
+				) ),
+				new Diff( array(
+					'en' => new DiffOpRemove( 'foo' )
+				) ),
+				new TermList()
+			),
+			'add an existing language is no-op' => array(
+				new TermList( array(
+					new Term( 'en', 'foo' )
+				) ),
+				new Diff( array(
+					'en' => new DiffOpAdd( 'bar' )
+				) ),
+				new TermList( array(
+					new Term( 'en', 'foo' )
+				) )
+			),
+			'add two terms' => array(
+				new TermList( array(
+					new Term( 'en', 'foo' )
+				) ),
+				new Diff( array(
+					'de' => new DiffOpAdd( 'bar' ),
+					'nl' => new DiffOpAdd( 'baz' )
+				) ),
+				new TermList( array(
+					new Term( 'en', 'foo' ),
+					new Term( 'de', 'bar' ),
+					new Term( 'nl', 'baz' )
+				) )
+			),
+			'remove a not existing language is no-op' => array(
+				new TermList( array(
+					new Term( 'en', 'foo' )
+				) ),
+				new Diff( array(
+					'de' => new DiffOpRemove( 'bar' )
+				) ),
+				new TermList( array(
+					new Term( 'en', 'foo' )
+				) )
+			),
+			'change a different value is no-op' => array(
+				new TermList( array(
+					new Term( 'en', 'foo' )
+				) ),
+				new Diff( array(
+					'en' => new DiffOpChange( 'bar', 'baz' )
+				) ),
+				new TermList( array(
+					new Term( 'en', 'foo' )
+				) )
+			),
+			'remove a different value is no-op' => array(
+				new TermList( array(
+					new Term( 'en', 'foo' )
+				) ),
+				new Diff( array(
+					'en' => new DiffOpRemove( 'bar' )
+				) ),
+				new TermList( array(
+					new Term( 'en', 'foo' )
+				) )
+			),
+			'complex diff (associative)' => array(
+				new TermList( array(
+					new Term( 'en', 'foo' ),
+					new Term( 'de', 'bar' ),
+					new Term( 'nl', 'baz' )
+				) ),
+				new Diff( array(
+					'en' => new DiffOpChange( 'foo', 'bar' ),
+					'de' => new DiffOpRemove( 'bar' ),
+					'nl' => new DiffOpChange( 'bar', 'foo' ),
+					'it' => new DiffOpAdd( 'foo' )
+				), true ),
+				new TermList( array(
+					new Term( 'en', 'bar' ),
+					new Term( 'nl', 'baz' ),
+					new Term( 'it', 'foo' )
+				) )
+			),
+			'complex diff (non-associative)' => array(
+				new TermList( array(
+					new Term( 'en', 'foo' ),
+					new Term( 'de', 'bar' ),
+					new Term( 'nl', 'baz' )
+				) ),
+				new Diff( array(
+					'en' => new DiffOpChange( 'foo', 'bar' ),
+					'de' => new DiffOpRemove( 'bar' ),
+					'nl' => new DiffOpChange( 'bar', 'foo' ),
+					'it' => new DiffOpAdd( 'foo' )
+				), false ),
+				new TermList( array(
+					new Term( 'en', 'bar' ),
+					new Term( 'nl', 'baz' ),
+					new Term( 'it', 'foo' )
+				) )
+			),
+			'complex diff (auto-detected)' => array(
+				new TermList( array(
+					new Term( 'en', 'foo' ),
+					new Term( 'de', 'bar' ),
+					new Term( 'nl', 'baz' )
+				) ),
+				new Diff( array(
+					'en' => new DiffOpChange( 'foo', 'bar' ),
+					'de' => new DiffOpRemove( 'bar' ),
+					'nl' => new DiffOpChange( 'bar', 'foo' ),
+					'it' => new DiffOpAdd( 'foo' )
+				) ),
+				new TermList( array(
+					new Term( 'en', 'bar' ),
+					new Term( 'nl', 'baz' ),
+					new Term( 'it', 'foo' )
+				) )
+			),
+		);
+	}
+
+	/**
+	 * @dataProvider providePatchTermList
+	 */
+	public function testPatchTermList( TermList $terms, Diff $patch, TermList $expected ) {
+		$patcher = new TermListPatcher();
+		$patcher->patchTermList( $terms, $patch );
+
+		$this->assertSame( $expected->toTextArray(), $terms->toTextArray() );
+	}
+
+}


### PR DESCRIPTION
This pull request is mainly about moving code around and creating a lot of test cases.

It consists of three commits that can be reviewed individually.

After this pull request, FingerprintPatcher is unused and can be removed. We have to make sure that all test cases in FingerprintPatcherTest are also present in TermListPatcherTest and AliasGroupListPatcher test.

To make the new classes actually useful, we have to move them out of the Internal namespace and make them package public.
