### PR TITLE
Add missing type hints to getters that return mocks

### DIFF
--- a/tests/unit/EntityId/EntityIdLabelFormatterTest.php
+++ b/tests/unit/EntityId/EntityIdLabelFormatterTest.php
@@ -7,6 +7,7 @@ use Wikibase\DataModel\Entity\EntityId;
 use Wikibase\DataModel\Entity\ItemId;
 use Wikibase\DataModel\Entity\PropertyId;
 use Wikibase\DataModel\Services\EntityId\EntityIdLabelFormatter;
+use Wikibase\DataModel\Services\Lookup\LabelDescriptionLookup;
 use Wikibase\DataModel\Services\Lookup\LabelDescriptionLookupException;
 use Wikibase\DataModel\Term\Term;
 
@@ -54,6 +55,11 @@ class EntityIdLabelFormatterTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( $expectedString, $formattedValue );
 	}
 
+	/**
+	 * @param string $languageCode
+	 *
+	 * @return LabelDescriptionLookup
+	 */
 	protected function getLabelDescriptionLookup( $languageCode ) {
 		$labelDescriptionLookup = $this->getMockBuilder( 'Wikibase\DataModel\Services\Lookup\LabelDescriptionLookup' )
 			->disableOriginalConstructor()

--- a/tests/unit/Statement/Filter/DataTypeStatementFilterTest.php
+++ b/tests/unit/Statement/Filter/DataTypeStatementFilterTest.php
@@ -4,6 +4,7 @@ namespace Wikibase\DataModel\Services\Tests\Statement\Filter;
 
 use PHPUnit_Framework_TestCase;
 use Wikibase\DataModel\Entity\PropertyId;
+use Wikibase\DataModel\Services\Lookup\PropertyDataTypeLookup;
 use Wikibase\DataModel\Services\Lookup\PropertyDataTypeLookupException;
 use Wikibase\DataModel\Services\Statement\Filter\DataTypeStatementFilter;
 use Wikibase\DataModel\Snak\PropertyNoValueSnak;
@@ -17,6 +18,9 @@ use Wikibase\DataModel\Statement\Statement;
  */
 class DataTypeStatementFilterTest extends PHPUnit_Framework_TestCase {
 
+	/**
+	 * @return PropertyDataTypeLookup
+	 */
 	private function getDataTypeLookup() {
 		$dataTypeLookup = $this->getMock(
 			'Wikibase\DataModel\Services\Lookup\PropertyDataTypeLookup'

--- a/tests/unit/Statement/Grouper/FilteringStatementGrouperTest.php
+++ b/tests/unit/Statement/Grouper/FilteringStatementGrouperTest.php
@@ -6,6 +6,7 @@ use PHPUnit_Framework_TestCase;
 use Wikibase\DataModel\Services\Statement\Grouper\FilteringStatementGrouper;
 use Wikibase\DataModel\Snak\PropertyNoValueSnak;
 use Wikibase\DataModel\Statement\Statement;
+use Wikibase\DataModel\Statement\StatementFilter;
 use Wikibase\DataModel\Statement\StatementList;
 
 /**
@@ -16,6 +17,11 @@ use Wikibase\DataModel\Statement\StatementList;
  */
 class FilteringStatementGrouperTest extends PHPUnit_Framework_TestCase {
 
+	/**
+	 * @param string $propertyId
+	 *
+	 * @return StatementFilter
+	 */
 	private function newStatementFilter( $propertyId = 'P1' ) {
 		$filter = $this->getMock( 'Wikibase\DataModel\Statement\StatementFilter' );
 


### PR DESCRIPTION
I found candidates with a pretty complicated regex, searching for functions that construct and return a mock but do not have a PHPDoc block. This improves type safety and reduces the number of warnings analysis tools like PHPStorm report.
