### PR TITLE
Fix broken FingerprintPatcherTest

### DIFF
--- a/tests/unit/Diff/Internal/FingerprintPatcherTest.php
+++ b/tests/unit/Diff/Internal/FingerprintPatcherTest.php
@@ -94,6 +94,11 @@ class FingerprintPatcherTest extends \PHPUnit_Framework_TestCase {
 				'en' => new Diff( array( new DiffOpChange( 'en-old', 'en-new' ) ), true ),
 				'fa' => new Diff( array( new DiffOpRemove( 'fa-old' ) ), true ),
 			) ),
+			'non-associative diffs containing atomic ops' => array( array(
+				'de' => new Diff( array( new DiffOpAdd( 'foo' ) ), true ),
+				'en' => new Diff( array( new DiffOpChange( 'en-old', 'en-new' ) ), false ),
+				'fa' => new Diff( array( new DiffOpRemove( 'fa-old' ) ), true ),
+			) ),
 			'partly associative diffs (auto-detected) containing atomic ops' => array( array(
 				'de' => new Diff( array( new DiffOpAdd( 'foo' ) ) ),
 				'en' => new Diff( array( new DiffOpChange( 'en-old', 'en-new' ) ) ),
@@ -194,11 +199,6 @@ class FingerprintPatcherTest extends \PHPUnit_Framework_TestCase {
 				'aliases' => new Diff( array(
 					'de' => new Diff( array( new DiffOpChange( 'original', 'changed' ) ), true ),
 					'en' => new Diff( array( new DiffOpChange( 'original', 'changed' ) ), true ),
-				), true ),
-			) ),
-			'non-associative aliases change is ignored' => array( array(
-				'aliases' => new Diff( array(
-					'en' => new Diff( array( new DiffOpChange( 'conflict', 'changed' ) ), false ),
 				), true ),
 			) ),
 			'changing missing aliases is no-op (atomic)' => array( array(


### PR DESCRIPTION
This test was introduced in #126. #120 was merged the same time and broke master.

I tried to wrap my head around all this and understand what this was meant to do originally. I can't figure it out. Instead of what this patch now does it would be possible to add an

``` php
if ( $patch->isAssociative() !== false ) {
    return;
}
```

to line 180 in `getPatchedAliases` to restore the original behavior. But the new code makes it pretty obvious that this can't be a correct solution. Basically: why should a change operation on a single alias be valid when this "associative" flag is either not set or set to `true`, but be ignored (not fail) when it is `false`? What does it even mean for a alias change to be "associative" or not, and why can you set this as an explicit bool flag?

Note that the word "associative" does not appear at all in my rewrite of the fingerprint patcher. It's just not necessary, which means it was not used in the old implementation, except for the single place in question here.

Note that there are no array keys inside `new Diff( array( /* no array keys here */ ), $isAssociative )`.

I consider this a bug in all versions including the current 3.x.

This type of alias change is currently not used in production.

[Bug: T78298](http://phabricator.wikimedia.org/T78298)
