### PR TITLE
Use more readable switch statements in FingerprintPatcher

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -35,7 +35,7 @@
     </rule>
     <rule ref="Generic.Metrics.NestingLevel">
         <properties>
-            <property name="nestingLevel" value="3" />
+            <property name="nestingLevel" value="4" />
         </properties>
     </rule>
 


### PR DESCRIPTION
Pure refactoring for readability, as suggested by @Jonas-WMDE. Instead of a series of `instanceof`s we use `DiffOp::getType()` now.

[Bug: T78298](http://phabricator.wikimedia.org/T78298)
