### PR TITLE
Update DataModel version matrix in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,18 +6,18 @@ env:
 matrix:
   fast_finish: true
   include:
-    - env: DM=~4.2
+    - env: DM=~6.0
       php: 5.3
-    - env: DM=~4.2
+    - env: DM=@dev
       php: 5.4
-    - env: DM=~4.3@dev
+    - env: DM=~6.0
+      php: 5.5
+    - env: DM=~5.0
       php: 5.6
     - env: DM=~4.2
       php: 7
     - env: DM=~4.2
       php: hhvm
-    - env: DM=@dev
-      php: 5.6
   exclude:
     - env: THENEEDFORTHIS=FAIL
   allow_failures:


### PR DESCRIPTION
- PHP 5.6 was tested twice but PHP 5.5 was not.
- Testing with 4.3@dev is obsolete with 5.0.

Same in:
- https://github.com/wmde/WikibaseDataModelSerialization/pull/202
- https://github.com/wmde/WikibaseInternalSerialization/pull/108
