### PR TITLE
Make differs/patchers required by MediaInfo public

### DIFF
--- a/src/Diff/Internal/FingerprintPatcher.php
+++ b/src/Diff/Internal/FingerprintPatcher.php
@@ -4,12 +4,10 @@ namespace Wikibase\DataModel\Services\Diff\Internal;
 
 use Diff\Patcher\PatcherException;
 use Wikibase\DataModel\Services\Diff\EntityDiff;
+use Wikibase\DataModel\Services\Diff\TermListPatcher;
 use Wikibase\DataModel\Term\Fingerprint;
 
 /**
- * TODO: Class should be public.
- * TODO: Should this support actual edit conflict detection?
- *
  * Package private.
  *
  * @since 1.0

--- a/src/Diff/Internal/SiteLinkListPatcher.php
+++ b/src/Diff/Internal/SiteLinkListPatcher.php
@@ -10,9 +10,6 @@ use Wikibase\DataModel\Entity\ItemId;
 use Wikibase\DataModel\SiteLinkList;
 
 /**
- * TODO: Class should be public.
- * TODO: Should this support actual edit conflict detection?
- *
  * Package private.
  *
  * @license GPL-2.0+

--- a/src/Diff/ItemDiffer.php
+++ b/src/Diff/ItemDiffer.php
@@ -7,7 +7,6 @@ use InvalidArgumentException;
 use Wikibase\DataModel\Entity\EntityDocument;
 use Wikibase\DataModel\Entity\Item;
 use Wikibase\DataModel\Entity\ItemId;
-use Wikibase\DataModel\Services\Diff\Internal\StatementListDiffer;
 use Wikibase\DataModel\SiteLinkList;
 
 /**

--- a/src/Diff/ItemPatcher.php
+++ b/src/Diff/ItemPatcher.php
@@ -7,7 +7,6 @@ use Wikibase\DataModel\Entity\EntityDocument;
 use Wikibase\DataModel\Entity\Item;
 use Wikibase\DataModel\Services\Diff\Internal\FingerprintPatcher;
 use Wikibase\DataModel\Services\Diff\Internal\SiteLinkListPatcher;
-use Wikibase\DataModel\Services\Diff\Internal\StatementListPatcher;
 
 /**
  * @since 1.0
@@ -76,10 +75,10 @@ class ItemPatcher implements EntityPatcherStrategy {
 			) );
 		}
 
-		$item->setStatements( $this->statementListPatcher->getPatchedStatementList(
+		$this->statementListPatcher->patchStatementList(
 			$item->getStatements(),
 			$patch->getClaimsDiff()
-		) );
+		);
 	}
 
 }

--- a/src/Diff/PropertyDiffer.php
+++ b/src/Diff/PropertyDiffer.php
@@ -7,7 +7,6 @@ use Diff\DiffOp\DiffOp;
 use InvalidArgumentException;
 use Wikibase\DataModel\Entity\EntityDocument;
 use Wikibase\DataModel\Entity\Property;
-use Wikibase\DataModel\Services\Diff\Internal\StatementListDiffer;
 use Wikibase\DataModel\Statement\StatementList;
 
 /**

--- a/src/Diff/PropertyPatcher.php
+++ b/src/Diff/PropertyPatcher.php
@@ -6,7 +6,6 @@ use InvalidArgumentException;
 use Wikibase\DataModel\Entity\EntityDocument;
 use Wikibase\DataModel\Entity\Property;
 use Wikibase\DataModel\Services\Diff\Internal\FingerprintPatcher;
-use Wikibase\DataModel\Services\Diff\Internal\StatementListPatcher;
 
 /**
  * @since 1.0
@@ -62,10 +61,10 @@ class PropertyPatcher implements EntityPatcherStrategy {
 	private function patchProperty( Property $property, EntityDiff $patch ) {
 		$this->fingerprintPatcher->patchFingerprint( $property->getFingerprint(), $patch );
 
-		$property->setStatements( $this->statementListPatcher->getPatchedStatementList(
+		$this->statementListPatcher->patchStatementList(
 			$property->getStatements(),
 			$patch->getClaimsDiff()
-		) );
+		);
 	}
 
 }

--- a/src/Diff/StatementListDiffer.php
+++ b/src/Diff/StatementListDiffer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\DataModel\Services\Diff\Internal;
+namespace Wikibase\DataModel\Services\Diff;
 
 use Diff\Differ\MapDiffer;
 use Diff\DiffOp\Diff\Diff;
@@ -9,11 +9,7 @@ use Wikibase\DataModel\Statement\Statement;
 use Wikibase\DataModel\Statement\StatementList;
 
 /**
- * TODO: Class must be public.
- *
- * Package private.
- *
- * @since 1.0
+ * @since 3.6
  *
  * @license GPL-2.0+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >

--- a/src/Diff/StatementListPatcher.php
+++ b/src/Diff/StatementListPatcher.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\DataModel\Services\Diff\Internal;
+namespace Wikibase\DataModel\Services\Diff;
 
 use Diff\DiffOp\Diff\Diff;
 use Diff\DiffOp\DiffOp;
@@ -8,17 +8,11 @@ use Diff\DiffOp\DiffOpAdd;
 use Diff\DiffOp\DiffOpChange;
 use Diff\DiffOp\DiffOpRemove;
 use Diff\Patcher\PatcherException;
-use InvalidArgumentException;
 use Wikibase\DataModel\Statement\Statement;
 use Wikibase\DataModel\Statement\StatementList;
 
 /**
- * TODO: Class must be public.
- * TODO: Should this support actual edit conflict detection?
- *
- * Package private.
- *
- * @since 1.0
+ * @since 3.6
  *
  * @license GPL-2.0+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
@@ -101,21 +95,6 @@ class StatementListPatcher {
 		foreach ( $replacements as $statement ) {
 			$statements->addStatement( $statement );
 		}
-	}
-
-	/**
-	 * @deprecated since 3.6, use patchStatementList instead
-	 *
-	 * @param StatementList $statements
-	 * @param Diff $patch
-	 *
-	 * @throws InvalidArgumentException
-	 * @return StatementList
-	 */
-	public function getPatchedStatementList( StatementList $statements, Diff $patch ) {
-		$patched = clone $statements;
-		$this->patchStatementList( $patched, $patch );
-		return $patched;
 	}
 
 }

--- a/src/Diff/TermListPatcher.php
+++ b/src/Diff/TermListPatcher.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wikibase\DataModel\Services\Diff\Internal;
+namespace Wikibase\DataModel\Services\Diff;
 
 use Diff\DiffOp\AtomicDiffOp;
 use Diff\DiffOp\Diff\Diff;
@@ -11,8 +11,6 @@ use Diff\Patcher\PatcherException;
 use Wikibase\DataModel\Term\TermList;
 
 /**
- * Package private.
- *
  * @since 3.6
  *
  * @license GPL-2.0+

--- a/tests/unit/Diff/EntityDiffTest.php
+++ b/tests/unit/Diff/EntityDiffTest.php
@@ -8,7 +8,7 @@ use Diff\DiffOp\DiffOpChange;
 use Diff\DiffOp\DiffOpRemove;
 use PHPUnit_Framework_TestCase;
 use Wikibase\DataModel\Services\Diff\EntityDiff;
-use Wikibase\DataModel\Services\Diff\Internal\StatementListDiffer;
+use Wikibase\DataModel\Services\Diff\StatementListDiffer;
 use Wikibase\DataModel\Snak\PropertyNoValueSnak;
 use Wikibase\DataModel\Statement\Statement;
 use Wikibase\DataModel\Statement\StatementList;

--- a/tests/unit/Diff/StatementListDifferTest.php
+++ b/tests/unit/Diff/StatementListDifferTest.php
@@ -1,19 +1,19 @@
 <?php
 
-namespace Wikibase\DataModel\Services\Tests\Diff\Internal;
+namespace Wikibase\DataModel\Services\Tests\Diff;
 
 use DataValues\StringValue;
 use Diff\DiffOp\Diff\Diff;
 use Diff\DiffOp\DiffOpAdd;
 use Diff\DiffOp\DiffOpChange;
 use Diff\DiffOp\DiffOpRemove;
-use Wikibase\DataModel\Services\Diff\Internal\StatementListDiffer;
+use Wikibase\DataModel\Services\Diff\StatementListDiffer;
 use Wikibase\DataModel\Snak\PropertyValueSnak;
 use Wikibase\DataModel\Statement\Statement;
 use Wikibase\DataModel\Statement\StatementList;
 
 /**
- * @covers Wikibase\DataModel\Services\Diff\Internal\StatementListDiffer
+ * @covers Wikibase\DataModel\Services\Diff\StatementListDiffer
  *
  * @license GPL-2.0+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >

--- a/tests/unit/Diff/StatementListPatcherTest.php
+++ b/tests/unit/Diff/StatementListPatcherTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Wikibase\DataModel\Services\Tests\Diff\Internal;
+namespace Wikibase\DataModel\Services\Tests\Diff;
 
 use DataValues\StringValue;
 use Diff\DiffOp\Diff\Diff;
 use Diff\DiffOp\DiffOpAdd;
 use Diff\DiffOp\DiffOpChange;
 use Diff\DiffOp\DiffOpRemove;
-use Wikibase\DataModel\Services\Diff\Internal\StatementListPatcher;
+use Wikibase\DataModel\Services\Diff\StatementListPatcher;
 use Wikibase\DataModel\Snak\PropertyNoValueSnak;
 use Wikibase\DataModel\Snak\PropertySomeValueSnak;
 use Wikibase\DataModel\Snak\PropertyValueSnak;
@@ -15,7 +15,7 @@ use Wikibase\DataModel\Statement\Statement;
 use Wikibase\DataModel\Statement\StatementList;
 
 /**
- * @covers Wikibase\DataModel\Services\Diff\Internal\StatementListPatcher
+ * @covers Wikibase\DataModel\Services\Diff\StatementListPatcher
  *
  * @license GPL-2.0+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
@@ -225,10 +225,10 @@ class StatementListPatcherTest extends \PHPUnit_Framework_TestCase {
 	 */
 	public function testStatementOrder( StatementList $statements, Diff $patch, array $expectedGuids ) {
 		$patcher = new StatementListPatcher();
-		$patchedStatements = $patcher->getPatchedStatementList( $statements, $patch );
+		$patcher->patchStatementList( $statements, $patch );
 
 		$guids = array();
-		foreach ( $patchedStatements->toArray() as $statement ) {
+		foreach ( $statements->toArray() as $statement ) {
 			$guids[] = $statement->getGuid();
 		}
 		$this->assertSame( $expectedGuids, $guids );
@@ -240,11 +240,14 @@ class StatementListPatcherTest extends \PHPUnit_Framework_TestCase {
 		$this->assertListResultsFromPatch( $statements, $statements, new Diff() );
 	}
 
-	private function assertListResultsFromPatch( StatementList $expected, StatementList $original, Diff $patch ) {
+	private function assertListResultsFromPatch(
+		StatementList $expected,
+		StatementList $statements,
+		Diff $patch
+	) {
 		$patcher = new StatementListPatcher();
-		$clone = clone $original;
-		$this->assertEquals( $expected, $patcher->getPatchedStatementList( $original, $patch ) );
-		$this->assertEquals( $clone, $original, 'original must not change' );
+		$patcher->patchStatementList( $statements, $patch );
+		$this->assertEquals( $expected, $statements );
 	}
 
 	public function testFoo() {

--- a/tests/unit/Diff/TermListPatcherTest.php
+++ b/tests/unit/Diff/TermListPatcherTest.php
@@ -1,18 +1,18 @@
 <?php
 
-namespace Wikibase\DataModel\Services\Tests\Diff\Internal;
+namespace Wikibase\DataModel\Services\Tests\Diff;
 
 use Diff\DiffOp\Diff\Diff;
 use Diff\DiffOp\DiffOpAdd;
 use Diff\DiffOp\DiffOpChange;
 use Diff\DiffOp\DiffOpRemove;
 use PHPUnit_Framework_TestCase;
-use Wikibase\DataModel\Services\Diff\Internal\TermListPatcher;
+use Wikibase\DataModel\Services\Diff\TermListPatcher;
 use Wikibase\DataModel\Term\Term;
 use Wikibase\DataModel\Term\TermList;
 
 /**
- * @covers Wikibase\DataModel\Services\Diff\Internal\TermListPatcher
+ * @covers Wikibase\DataModel\Services\Diff\TermListPatcher
  *
  * @license GPL-2.0+
  * @author Bene* < benestar.wikimedia@gmail.com >


### PR DESCRIPTION
Note that this conflicts with #141! Please merge #141 first.

For MediaInfo this is a breaking change because this will break the current implementation that uses classes that are in the "Internal" namespace and marked as "packed private" in the class level documentation. However, from the perspective of this component this is not a breaking change and should, in my opinion, go into the planned 3.6 release.
