### PR TITLE
Add PrefixMappingEntityIdParser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,13 @@ matrix:
   include:
     - env: DM=@dev
       php: 5.5
-    - env: DM=~6.0
+    - env: DM=~6.2
       php: 5.5
-    - env: DM=~6.0
+    - env: DM=~6.2
       php: 5.6
-    - env: DM=~5.0
+    - env: DM=~6.2
       php: 7
-    - env: DM=~4.2
+    - env: DM=~6.2
       php: hhvm
   exclude:
     - env: THENEEDFORTHIS=FAIL

--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,10 @@
 	},
 	"require": {
 		"php": ">=5.5.0",
-		"wikibase/data-model": "~6.0|~5.0|~4.2",
+		"wikibase/data-model": "~6.2",
 		"data-values/data-values": "~0.1|~1.0",
-		"diff/diff": "~2.0|~1.0"
+		"diff/diff": "~2.0|~1.0",
+		"wikimedia/assert": "~0.2.2"
 	},
 	"require-dev": {
 		"squizlabs/php_codesniffer": "~2.3",

--- a/src/EntityId/PrefixMappingEntityIdParser.php
+++ b/src/EntityId/PrefixMappingEntityIdParser.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Wikibase\DataModel\Services\EntityId;
+
+use Wikimedia\Assert\Assert;
+use Wikimedia\Assert\ParameterAssertionException;
+use Wikimedia\Assert\ParameterTypeException;
+use Wikibase\DataModel\Entity\EntityId;
+use Wikibase\DataModel\Entity\EntityIdParser;
+use Wikibase\DataModel\Entity\EntityIdParsingException;
+
+/**
+ * EntityIdParser that adds a fixed prefix, maps a prefix of id serialization
+ * to a local prefix according to the prefix mapping
+ * and parses resulting string as an EntityId.
+ * This can be used to prefix IDs of entities coming from a foreign repository
+ * with the repository name to avoid clashes with IDs of local entities.
+ *
+ * @since 3.7
+ *
+ * @license GPL-2.0+
+ */
+class PrefixMappingEntityIdParser implements EntityIdParser {
+
+	/**
+	 * @var string
+	 */
+	private $prefix;
+
+	/**
+	 * @var string[]
+	 */
+	private $prefixMapping;
+
+	/**
+	 * @var EntityIdParser
+	 */
+	private $idParser;
+
+	/**
+	 * @param string $prefix Prefix to be added. It should not contain a colon, in particular at the end of the prefix
+	 * @param string[] $prefixMapping
+	 * @param EntityIdParser $idParser
+	 *
+	 * @throws ParameterTypeException
+	 * @throws ParameterAssertionException
+	 */
+	public function __construct( $prefix, array $prefixMapping, EntityIdParser $idParser ) {
+		Assert::parameterType( 'string', $prefix, '$prefix' );
+		Assert::parameter( strpos( $prefix, ':' ) === false, '$prefix', 'must not contain a colon' );
+		Assert::parameterElementType( 'string', $prefixMapping, '$prefixMapping' );
+		Assert::parameterElementType( 'string', array_keys( $prefixMapping ), 'array_keys( $prefixMapping )' );
+		$this->prefix = $prefix;
+		$this->prefixMapping = $prefixMapping;
+		$this->idParser = $idParser;
+	}
+
+	/**
+	 * Adds a fixed prefix to the serialization id and maps it according to the prefix mapping definition.
+	 * Resulting id serialization is parsed as an EntityId.
+	 *
+	 * @param string $idSerialization
+	 *
+	 * @return EntityId
+	 * @throws EntityIdParsingException
+	 */
+	public function parse( $idSerialization ) {
+		list( $repoName, $extraPrefixes, $relativeId ) = EntityId::splitSerialization( $idSerialization );
+		if ( isset( $this->prefixMapping[$repoName] ) ) {
+			$prefixedIdSerialization = EntityId::joinSerialization( [
+				$this->prefixMapping[$repoName], $extraPrefixes, $relativeId
+			] );
+		} else {
+			$prefixedIdSerialization = EntityId::joinSerialization( [ $this->prefix, '', $idSerialization ] );
+		}
+		return $this->idParser->parse( $prefixedIdSerialization );
+	}
+
+}

--- a/tests/unit/EntityId/PrefixMappingEntityIdParserTest.php
+++ b/tests/unit/EntityId/PrefixMappingEntityIdParserTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Tests\EntityId;
+
+use Wikibase\DataModel\Entity\BasicEntityIdParser;
+use Wikibase\DataModel\Entity\EntityIdParser;
+use Wikibase\DataModel\Entity\EntityIdParsingException;
+use Wikibase\DataModel\Entity\EntityId;
+use Wikibase\DataModel\Entity\ItemId;
+use Wikibase\DataModel\Entity\PropertyId;
+use Wikibase\DataModel\Services\EntityId\PrefixMappingEntityIdParser;
+use Wikimedia\Assert\ParameterAssertionException;
+use Wikimedia\Assert\ParameterElementTypeException;
+use Wikimedia\Assert\ParameterTypeException;
+
+/**
+ * @covers Wikibase\DataModel\Services\EntityId\PrefixMappingEntityIdParser
+ *
+ * @license GPL-2.0+
+ */
+class PrefixMappingEntityIdParserTest extends \PHPUnit_Framework_TestCase {
+
+	private function getRegularParser() {
+		return new BasicEntityIdParser();
+	}
+
+	/**
+	 * @dataProvider provideValidIdSerialization
+	 */
+	public function testGivenNoPrefixMapping_prefixIsAddedToIdSerialization( $prefix, $input, EntityId $expectedId ) {
+		$parser = new PrefixMappingEntityIdParser(
+			$prefix,
+			[],
+			$this->getRegularParser()
+		);
+		$this->assertEquals( $expectedId, $parser->parse( $input ) );
+	}
+
+	public function provideValidIdSerialization() {
+		return [
+			[ 'wikidata', 'Q1337', new ItemId( 'wikidata:Q1337' ) ],
+			[ '', 'Q1337', new ItemId( 'Q1337' ) ],
+			[ 'foo', 'P123', new PropertyId( 'foo:P123' ) ],
+			[ 'foo', 'bar:Q1337', new ItemId( 'foo:bar:Q1337' ) ],
+			[ 'foo', 'foo:Q1337', new ItemId( 'foo:foo:Q1337' ) ],
+		];
+	}
+
+	/**
+	 * @dataProvider provideMappedSerializationId
+	 */
+	public function testGivenPrefixIsMapped_mappedOneIsUsed(
+		$prefix,
+		array $prefixMapping,
+		$foreignId,
+		EntityId $expectedEntityId
+	) {
+		$regularParser = $this->getRegularParser();
+		$parser = new PrefixMappingEntityIdParser( $prefix, $prefixMapping, $regularParser );
+		$this->assertEquals( $expectedEntityId, $parser->parse( $foreignId ) );
+	}
+
+	public function provideMappedSerializationId() {
+		return [
+			[ 'foo', [ 'bar' => 'wd' ], 'bar:Q1337', new ItemId( 'wd:Q1337' ) ],
+			[ 'foo', [ 'bar' => 'wd' ], 'bar:x:Q1337', new ItemId( 'wd:x:Q1337' ) ],
+		];
+	}
+
+	public function testGivenPrefixIsNotMapped_prefixIsAddedToIdSerialization() {
+		$expectedId = new ItemId( 'foo:x:bar:Q1337' );
+		$regularParser = $this->getRegularParser();
+		$parser = new PrefixMappingEntityIdParser( 'foo', [ 'bar' => 'wd' ], $regularParser );
+		$this->assertEquals( $expectedId, $parser->parse( 'x:bar:Q1337' ) );
+	}
+
+	public function testEntityIdParsingExceptionsAreNotCaught() {
+		$regularParser = $this->getMock( EntityIdParser::class );
+		$regularParser->expects( $this->any() )
+			->method( 'parse' )
+			->will( $this->throwException( new EntityIdParsingException() ) );
+		$parser = new PrefixMappingEntityIdParser( 'wikidata', [], $regularParser );
+		$this->setExpectedException( EntityIdParsingException::class );
+		$parser->parse( 'QQQ' );
+	}
+
+	/**
+	 * @dataProvider provideInvalidPrefix
+	 */
+	public function testGivenInvalidPrefix_exceptionIsThrown( $prefix ) {
+		$regularParser = $this->getMock( EntityIdParser::class );
+		$this->setExpectedException( ParameterTypeException::class );
+		new PrefixMappingEntityIdParser( $prefix, [], $regularParser );
+	}
+
+	public function provideInvalidPrefix() {
+		return [
+			[ 1337 ],
+			[ null ],
+		];
+	}
+
+	public function testGivenPrefixIncludingColon_exceptionIsThrown() {
+		$regularParser = $this->getMock( EntityIdParser::class );
+		$this->setExpectedException( ParameterAssertionException::class );
+		new PrefixMappingEntityIdParser( 'wikidata:', [], $regularParser );
+	}
+
+	/**
+	 * @dataProvider provideInvalidPrefixMapping
+	 */
+	public function testGivenInvalidPrefixMapping_exceptionIsThrown( array $prefixMapping ) {
+		$regularParser = $this->getMock( EntityIdParser::class );
+		$this->setExpectedException( ParameterElementTypeException::class );
+		new PrefixMappingEntityIdParser( 'foo', $prefixMapping, $regularParser );
+	}
+
+	public function provideInvalidPrefixMapping() {
+		return [
+			'non-string values in prefix mapping' => [ [ 'bar' => 123 ] ],
+			'non-string keys in prefix mapping' => [ [ 0 => 'wd' ] ],
+		];
+	}
+
+}

--- a/tests/unit/EntityId/PrefixMappingEntityIdParserTest.php
+++ b/tests/unit/EntityId/PrefixMappingEntityIdParserTest.php
@@ -10,8 +10,6 @@ use Wikibase\DataModel\Entity\ItemId;
 use Wikibase\DataModel\Entity\PropertyId;
 use Wikibase\DataModel\Services\EntityId\PrefixMappingEntityIdParser;
 use Wikimedia\Assert\ParameterAssertionException;
-use Wikimedia\Assert\ParameterElementTypeException;
-use Wikimedia\Assert\ParameterTypeException;
 
 /**
  * @covers Wikibase\DataModel\Services\EntityId\PrefixMappingEntityIdParser
@@ -27,10 +25,11 @@ class PrefixMappingEntityIdParserTest extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @dataProvider provideValidIdSerialization
 	 */
-	public function testGivenNoPrefixMapping_prefixIsAddedToIdSerialization( $prefix, $input, EntityId $expectedId ) {
+	public function testGivenOnlyDefaultPrefixMapping_prefixIsAddedToIdSerialization(
+		array $prefixMapping, $input, EntityId $expectedId
+	) {
 		$parser = new PrefixMappingEntityIdParser(
-			$prefix,
-			[],
+			$prefixMapping,
 			$this->getRegularParser()
 		);
 		$this->assertEquals( $expectedId, $parser->parse( $input ) );
@@ -38,11 +37,11 @@ class PrefixMappingEntityIdParserTest extends \PHPUnit_Framework_TestCase {
 
 	public function provideValidIdSerialization() {
 		return [
-			[ 'wikidata', 'Q1337', new ItemId( 'wikidata:Q1337' ) ],
-			[ '', 'Q1337', new ItemId( 'Q1337' ) ],
-			[ 'foo', 'P123', new PropertyId( 'foo:P123' ) ],
-			[ 'foo', 'bar:Q1337', new ItemId( 'foo:bar:Q1337' ) ],
-			[ 'foo', 'foo:Q1337', new ItemId( 'foo:foo:Q1337' ) ],
+			[ [ '' => 'wikidata' ], 'Q1337', new ItemId( 'wikidata:Q1337' ) ],
+			[ [ '' => '' ], 'Q1337', new ItemId( 'Q1337' ) ],
+			[ [ '' => 'foo' ], 'P123', new PropertyId( 'foo:P123' ) ],
+			[ [ '' => 'foo' ], 'bar:Q1337', new ItemId( 'foo:bar:Q1337' ) ],
+			[ [ '' => 'foo' ], 'foo:Q1337', new ItemId( 'foo:foo:Q1337' ) ],
 		];
 	}
 
@@ -50,27 +49,26 @@ class PrefixMappingEntityIdParserTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider provideMappedSerializationId
 	 */
 	public function testGivenPrefixIsMapped_mappedOneIsUsed(
-		$prefix,
 		array $prefixMapping,
 		$foreignId,
 		EntityId $expectedEntityId
 	) {
 		$regularParser = $this->getRegularParser();
-		$parser = new PrefixMappingEntityIdParser( $prefix, $prefixMapping, $regularParser );
+		$parser = new PrefixMappingEntityIdParser( $prefixMapping, $regularParser );
 		$this->assertEquals( $expectedEntityId, $parser->parse( $foreignId ) );
 	}
 
 	public function provideMappedSerializationId() {
 		return [
-			[ 'foo', [ 'bar' => 'wd' ], 'bar:Q1337', new ItemId( 'wd:Q1337' ) ],
-			[ 'foo', [ 'bar' => 'wd' ], 'bar:x:Q1337', new ItemId( 'wd:x:Q1337' ) ],
+			[ [ '' => 'foo', 'bar' => 'wd' ], 'bar:Q1337', new ItemId( 'wd:Q1337' ) ],
+			[ [ '' => 'foo', 'bar' => 'wd' ], 'bar:x:Q1337', new ItemId( 'wd:x:Q1337' ) ],
 		];
 	}
 
-	public function testGivenPrefixIsNotMapped_prefixIsAddedToIdSerialization() {
+	public function testGivenPrefixIsNotMapped_defaultPrefixIsAddedToIdSerialization() {
 		$expectedId = new ItemId( 'foo:x:bar:Q1337' );
 		$regularParser = $this->getRegularParser();
-		$parser = new PrefixMappingEntityIdParser( 'foo', [ 'bar' => 'wd' ], $regularParser );
+		$parser = new PrefixMappingEntityIdParser( [ '' => 'foo', 'bar' => 'wd' ], $regularParser );
 		$this->assertEquals( $expectedId, $parser->parse( 'x:bar:Q1337' ) );
 	}
 
@@ -79,31 +77,9 @@ class PrefixMappingEntityIdParserTest extends \PHPUnit_Framework_TestCase {
 		$regularParser->expects( $this->any() )
 			->method( 'parse' )
 			->will( $this->throwException( new EntityIdParsingException() ) );
-		$parser = new PrefixMappingEntityIdParser( 'wikidata', [], $regularParser );
+		$parser = new PrefixMappingEntityIdParser( [ '' => 'wikidata' ], $regularParser );
 		$this->setExpectedException( EntityIdParsingException::class );
 		$parser->parse( 'QQQ' );
-	}
-
-	/**
-	 * @dataProvider provideInvalidPrefix
-	 */
-	public function testGivenInvalidPrefix_exceptionIsThrown( $prefix ) {
-		$regularParser = $this->getMock( EntityIdParser::class );
-		$this->setExpectedException( ParameterTypeException::class );
-		new PrefixMappingEntityIdParser( $prefix, [], $regularParser );
-	}
-
-	public function provideInvalidPrefix() {
-		return [
-			[ 1337 ],
-			[ null ],
-		];
-	}
-
-	public function testGivenPrefixIncludingColon_exceptionIsThrown() {
-		$regularParser = $this->getMock( EntityIdParser::class );
-		$this->setExpectedException( ParameterAssertionException::class );
-		new PrefixMappingEntityIdParser( 'wikidata:', [], $regularParser );
 	}
 
 	/**
@@ -111,14 +87,16 @@ class PrefixMappingEntityIdParserTest extends \PHPUnit_Framework_TestCase {
 	 */
 	public function testGivenInvalidPrefixMapping_exceptionIsThrown( array $prefixMapping ) {
 		$regularParser = $this->getMock( EntityIdParser::class );
-		$this->setExpectedException( ParameterElementTypeException::class );
-		new PrefixMappingEntityIdParser( 'foo', $prefixMapping, $regularParser );
+		$this->setExpectedException( ParameterAssertionException::class );
+		new PrefixMappingEntityIdParser( $prefixMapping, $regularParser );
 	}
 
 	public function provideInvalidPrefixMapping() {
 		return [
-			'non-string values in prefix mapping' => [ [ 'bar' => 123 ] ],
-			'non-string keys in prefix mapping' => [ [ 0 => 'wd' ] ],
+			'no empty-string key in prefix mapping' => [ [] ],
+			'non-string values in prefix mapping' => [ [ '' => 123 ] ],
+			'non-string keys in prefix mapping' => [ [ '' => 'foo', 0 => 'wd' ] ],
+			'prefix mapping values containing colons' => [ [ '' => 'wikidata:' ] ],
 		];
 	}
 


### PR DESCRIPTION
The parser can be used to prefix IDs of foreign entities with a repository name, and resolve foreign repository prefixes to local prefixes based on the prefix mapping.

~~This depends on https://github.com/wmde/WikibaseDataModel/pull/679 and tests will be failing until that PR is merged.~~

~~Also I just realized that his repository might not be a right location for the new parser. As it relies on a feature to be added in DataModel 6.2 (or so), having the parser here would break DataModelServices compatibility with any earlier DataModel versions. I guess we want to keep this broad compatibility. Should I rather put this parser in the DataModel repo?~~

Ticket: [T146274](https://phabricator.wikimedia.org/T146274)