### PR TITLE
Add PrefixMappingEntityIdParserFactory

### DIFF
--- a/src/EntityId/PrefixMappingEntityIdParserFactory.php
+++ b/src/EntityId/PrefixMappingEntityIdParserFactory.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Wikibase\DataModel\Services\EntityId;
+
+use Wikibase\DataModel\Entity\EntityIdParser;
+use Wikimedia\Assert\Assert;
+use Wikimedia\Assert\ParameterAssertionException;
+
+/**
+ * @since 3.7
+ *
+ * @license GPL-2.0+
+ */
+class PrefixMappingEntityIdParserFactory {
+
+	/**
+	 * @var string[]
+	 */
+	private $idPrefixMapping;
+
+	/**
+	 * @var EntityIdParser
+	 */
+	private $parser;
+
+	/**
+	 * @param EntityIdParser $parser
+	 * @param array $idPrefixMapping An associative array mapping repository names (strings) to id serialization
+	 *        prefix mappings specific to the particular repository (@see PrefixMappingEntityIdParser).
+	 *        If an empty-string key is provided in the mapping for some repository, its value must be the same
+	 *        as the repository name.
+	 *
+	 * @throws ParameterAssertionException
+	 */
+	public function __construct( EntityIdParser $parser, array $idPrefixMapping ) {
+		Assert::parameterElementType( 'string', array_keys( $idPrefixMapping ), 'array_keys( $idPrefixMapping)' );
+		foreach ( $idPrefixMapping as $repositoryName => $mapping ) {
+			Assert::parameter(
+				strpos( $repositoryName, ':' ) === false,
+				'keys in $idPrefixMapping',
+				'must not contain a colon'
+			);
+			Assert::parameterType( 'array', $mapping, '$idPrefixMapping[' . $repositoryName .']' );
+			Assert::parameterElementType( 'string', $mapping, '$idPrefixMapping[' . $repositoryName .']' );
+			Assert::parameterElementType(
+				'string',
+				array_keys( $mapping ),
+				'array_keys( $idPrefixMapping[' . $repositoryName .'] )'
+			);
+			Assert::parameter(
+				!array_key_exists( '', $mapping ) || $mapping[''] === $repositoryName,
+				'$idPrefixMapping[' . $repositoryName .'] )',
+				'must either not contain empty-string prefix mapping or it must be equal to repository name'
+			);
+		}
+
+		$this->idPrefixMapping = $idPrefixMapping;
+		$this->parser = $parser;
+	}
+
+	/**
+	 * Create a PrefixMappingEntityIdParser for the particular repository using id prefix mappings
+	 * defined in the constructor.
+	 *
+	 * @param string $repository
+	 *
+	 * @return PrefixMappingEntityIdParser
+	 * @throws ParameterAssertionException
+	 */
+	public function getIdParser( $repository ) {
+		Assert::parameterType( 'string', $repository, '$repository' );
+		Assert::parameter( strpos( $repository, ':' ) === false, '$repository', 'must not contain a colon' );
+		$mapping = [ '' => $repository ];
+		if ( isset( $this->idPrefixMapping[$repository] ) ) {
+			$mapping = array_merge( $mapping, $this->idPrefixMapping[$repository] );
+		}
+		return new PrefixMappingEntityIdParser( $mapping, $this->parser );
+	}
+
+}

--- a/tests/unit/EntityId/PrefixMappingEntityIdParserFactoryTest.php
+++ b/tests/unit/EntityId/PrefixMappingEntityIdParserFactoryTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Tests\EntityId;
+
+use Wikibase\DataModel\Entity\EntityIdParser;
+use Wikibase\DataModel\Services\EntityId\PrefixMappingEntityIdParser;
+use Wikibase\DataModel\Services\EntityId\PrefixMappingEntityIdParserFactory;
+use Wikimedia\Assert\ParameterAssertionException;
+use Wikimedia\Assert\ParameterTypeException;
+
+/**
+ * @covers Wikibase\DataModel\Services\EntityId\PrefixMappingEntityIdParserFactory
+ *
+ * @license GPL-2.0+
+ */
+class PrefixMappingEntityIdParserFactoryTest extends \PHPUnit_Framework_TestCase {
+
+	private function getDummyEntityIdParser() {
+		return $this->getMock( EntityIdParser::class );
+	}
+
+	public function testGetIdParser_repositoryWithKnownMapping() {
+		$dummyParser = $this->getDummyEntityIdParser();
+		$idPrefixMapping = [
+			'foo' => [ 'd' => 'de', 'e' => 'en', ],
+		];
+		$factory = new PrefixMappingEntityIdParserFactory( $dummyParser, $idPrefixMapping );
+		$this->assertEquals(
+			new PrefixMappingEntityIdParser( [ ''  => 'foo', 'd' => 'de', 'e' => 'en' ], $dummyParser ),
+			$factory->getIdParser( 'foo' )
+		);
+	}
+
+	public function testGetIdParser_repositoryWithoutKnownMapping() {
+		$dummyParser = $this->getDummyEntityIdParser();
+		$idPrefixMapping = [
+			'foo' => [ 'd' => 'de', 'e' => 'en', ],
+		];
+		$factory = new PrefixMappingEntityIdParserFactory( $dummyParser, $idPrefixMapping );
+		$this->assertEquals(
+			new PrefixMappingEntityIdParser( [ '' => 'bar' ], $dummyParser ),
+			$factory->getIdParser( 'bar' )
+		);
+	}
+
+	public function testGetIdParser_noIdPrefixMappings() {
+		$dummyParser = $this->getDummyEntityIdParser();
+		$factory = new PrefixMappingEntityIdParserFactory( $dummyParser, [] );
+		$this->assertEquals(
+			new PrefixMappingEntityIdParser( [ '' => 'foo' ], $dummyParser ),
+			$factory->getIdParser( 'foo' )
+		);
+	}
+
+	public function testGivenNonStringRepository_exceptionIsThrown() {
+		$factory = new PrefixMappingEntityIdParserFactory( $this->getDummyEntityIdParser(), [] );
+		$this->setExpectedException( ParameterTypeException::class );
+		$factory->getIdParser( 111 );
+	}
+
+	public function testGivenRepositoryIncludingColon_exceptionIsThrown() {
+		$factory = new PrefixMappingEntityIdParserFactory( $this->getDummyEntityIdParser(), [] );
+		$this->setExpectedException( ParameterAssertionException::class );
+		$factory->getIdParser( 'en:' );
+	}
+
+	/**
+	 * @dataProvider provideInvalidIdPrefixMapping
+	 */
+	public function testGivenInvalidIdPrefixMapping_exceptionIsThrown( array $mapping ) {
+		$this->setExpectedException( ParameterAssertionException::class );
+		new PrefixMappingEntityIdParserFactory( $this->getDummyEntityIdParser(), $mapping );
+	}
+
+	public function provideInvalidIdPrefixMapping() {
+		return [
+			'id prefix mapping values are not arrays' => [ [ 'foo' => 'bar' ] ],
+			'non-string keys in id prefix mapping' => [ [ 0 => [ 'd' => 'wd' ] ] ],
+			'non-string values in inner mapping' => [ [ 'foo' => [ 'd' => 123 ] ] ],
+			'non-string keys in inner mapping' => [ [ 'foo' => [ 0 => 'wd' ] ] ],
+			'keys containing colons in id prefix mapping' => [ [ 'fo:o' => [ 'd' => 'wd' ] ] ],
+			'default prefix mapping differs from repository name' => [ [ 'foo' => [ '' => 'bar' ] ] ],
+		];
+	}
+
+}


### PR DESCRIPTION
Note: this contains commit(s) from https://github.com/wmde/WikibaseDataModelServices/pull/146. ~~CI tests will be failing as longs as that PR's tests fail (ie. until DataModel 6.2 is tagged).~~

The actual change of this PR is at https://github.com/wmde/WikibaseDataModelServices/pull/149/commits/35cb120b77c6a309e30245baec8d14459c9347a7.

Per what we discussed in https://github.com/wmde/WikibaseDataModelServices/pull/146 I will be making any improvements to this PR by adding commits on top of the first one, and finally squash all of them once the change is ready to go.

Ticket: [T146274](https://phabricator.wikimedia.org/T146274)