### PR TITLE
Add DispatchingEntityLookup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,13 @@ matrix:
   include:
     - env: DM=@dev
       php: 5.5
-    - env: DM=~6.2
+    - env: DM=~6.3
       php: 5.5
-    - env: DM=~6.2
+    - env: DM=~6.3
       php: 5.6
-    - env: DM=~6.2
+    - env: DM=~6.3
       php: 7
-    - env: DM=~6.2
+    - env: DM=~6.3
       php: hhvm
   exclude:
     - env: THENEEDFORTHIS=FAIL

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 	},
 	"require": {
 		"php": ">=5.5.0",
-		"wikibase/data-model": "~6.2",
+		"wikibase/data-model": "~6.3",
 		"data-values/data-values": "~0.1|~1.0",
 		"diff/diff": "~2.0|~1.0",
 		"wikimedia/assert": "~0.2.2"

--- a/src/Lookup/DispatchingEntityLookup.php
+++ b/src/Lookup/DispatchingEntityLookup.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Lookup;
+
+use Wikibase\DataModel\Assert\RepositoryNameAssert;
+use Wikibase\DataModel\Entity\EntityDocument;
+use Wikibase\DataModel\Entity\EntityId;
+use Wikimedia\Assert\Assert;
+use Wikimedia\Assert\ParameterAssertionException;
+
+/**
+ * Delegates lookup to the repository-specific EntityLookup
+ * based on the name of the repository an EntityId belongs to.
+ * This class does not strip repository prefixes of incoming
+ * entity IDs.
+ *
+ * @since 3.7
+ *
+ * @license GPL-2.0+
+ */
+class DispatchingEntityLookup implements EntityLookup {
+
+	/**
+	 * @var EntityLookup[]
+	 */
+	private $lookups;
+
+	/**
+	 * @since 3.7
+	 *
+	 * @param EntityLookup[] $lookups associative array with repository names (strings) as keys
+	 *                                and EntityLookup objects as values.
+	 *
+	 * @throws ParameterAssertionException
+	 */
+	public function __construct( array $lookups ) {
+		Assert::parameter(
+			!empty( $lookups ),
+			'$lookups',
+			'must must not be empty'
+		);
+		Assert::parameterElementType( EntityLookup::class, $lookups, '$lookups' );
+		RepositoryNameAssert::assertParameterKeysAreValidRepositoryNames( $lookups, '$lookups' );
+		$this->lookups = $lookups;
+	}
+
+	/**
+	 * @see EntityLookup::getEntity
+	 *
+	 * @since 3.7
+	 *
+	 * @param EntityId $entityId
+	 *
+	 * @return null|EntityDocument
+	 * @throws EntityLookupException
+	 * @throws UnknownForeignRepositoryException
+	 */
+	public function getEntity( EntityId $entityId ) {
+		$lookup = $this->getLookupForEntityId( $entityId );
+		return $lookup->getEntity( $entityId );
+	}
+
+	/**
+	 * @see EntityLookup::hasEntity
+	 *
+	 * @since 3.7
+	 *
+	 * @param EntityId $entityId
+	 *
+	 * @return bool
+	 * @throws EntityLookupException
+	 * @throws UnknownForeignRepositoryException
+	 */
+	public function hasEntity( EntityId $entityId ) {
+		$lookup = $this->getLookupForEntityId( $entityId );
+		return $lookup->hasEntity( $entityId );
+	}
+
+	/**
+	 * @param EntityId $entityId
+	 *
+	 * @return EntityLookup
+	 * @throws UnknownForeignRepositoryException
+	 */
+	private function getLookupForEntityId( EntityId $entityId ) {
+		$repo = $entityId->getRepositoryName();
+		if ( !isset( $this->lookups[$repo] ) ) {
+			throw new UnknownForeignRepositoryException( $entityId->getRepositoryName() );
+		}
+		return $this->lookups[$repo];
+	}
+
+}

--- a/tests/unit/Lookup/DispatchingEntityLookupTest.php
+++ b/tests/unit/Lookup/DispatchingEntityLookupTest.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Tests\Lookup;
+
+use Exception;
+use Wikibase\DataModel\Entity\ItemId;
+use Wikibase\DataModel\Entity\PropertyId;
+use Wikibase\DataModel\Services\Fixtures\FakeEntityDocument;
+use Wikibase\DataModel\Services\Lookup\DispatchingEntityLookup;
+use Wikibase\DataModel\Services\Lookup\EntityLookup;
+use Wikibase\DataModel\Services\Lookup\EntityLookupException;
+use Wikibase\DataModel\Services\Lookup\InMemoryEntityLookup;
+use Wikibase\DataModel\Services\Lookup\UnknownForeignRepositoryException;
+use Wikimedia\Assert\ParameterAssertionException;
+
+/**
+ * @covers Wikibase\DataModel\Services\Lookup\DispatchingEntityLookup
+ *
+ * @license GPL-2.0+
+ */
+class DispatchingEntityLookupTest extends \PHPUnit_Framework_TestCase {
+
+	/**
+	 * @dataProvider provideInvalidForeignLookups
+	 */
+	public function testGivenInvalidForeignLookups_exceptionIsThrown( array $lookups ) {
+		$this->setExpectedException( ParameterAssertionException::class );
+		new DispatchingEntityLookup( $lookups );
+	}
+
+	public function provideInvalidForeignLookups() {
+		return [
+			'no lookups given' => [ [] ],
+			'not an implementation of EntityLookup given as a lookup' => [
+				[ '' => new ItemId( 'Q123' ) ],
+			],
+			'non-string keys' => [
+				[ '' => new InMemoryEntityLookup(), 100 => new InMemoryEntityLookup(), ],
+			],
+			'repo name containing colon' => [
+				[ '' => new InMemoryEntityLookup(),	'fo:oo' => new InMemoryEntityLookup(), ],
+			],
+		];
+	}
+
+	public function testGivenExistingEntityId_getEntityReturnsTheEntity() {
+		$localLookup = new InMemoryEntityLookup();
+		$localLookup->addEntity( new FakeEntityDocument( new ItemId( 'Q1' ) ) );
+		$fooLookup = new InMemoryEntityLookup();
+		$fooLookup->addEntity( new FakeEntityDocument( new PropertyId( 'foo:P11' ) ) );
+
+		$dispatchingLookup = new DispatchingEntityLookup( [ '' => $localLookup, 'foo' => $fooLookup ] );
+
+		$expected = new FakeEntityDocument( new ItemId( 'Q1' ) );
+		$actual = $dispatchingLookup->getEntity( new ItemId( 'Q1' ) );
+		$this->assertTrue( $actual->equals( $expected ) );
+		$this->assertTrue( $actual->getId()->equals( new ItemId( 'Q1' ) ) );
+
+		$expected = new FakeEntityDocument( new PropertyId( 'foo:P11' ) );
+		$actual = $dispatchingLookup->getEntity( new PropertyId( 'foo:P11' ) );
+		$this->assertTrue( $actual->equals( $expected ) );
+		$this->assertTrue( $actual->getId()->equals( new PropertyId( 'foo:P11' ) ) );
+	}
+
+	public function testGivenNotExistingEntityIdFromKnownRepository_getEntityReturnsNull() {
+		$localLookup = new InMemoryEntityLookup();
+		$fooLookup = new InMemoryEntityLookup();
+		$dispatchingLookup = new DispatchingEntityLookup( [ '' => $localLookup, 'foo' => $fooLookup ] );
+		$this->assertNull( $dispatchingLookup->getEntity( new ItemId( 'Q1' ) ) );
+		$this->assertNull( $dispatchingLookup->getEntity( new ItemId( 'foo:Q19' ) ) );
+	}
+
+	/**
+	 * @param Exception $exception
+	 * @return \PHPUnit_Framework_MockObject_MockObject|EntityLookup
+	 */
+	private function getExceptionThrowingLookup( Exception $exception ) {
+		$lookup = $this->getMock( EntityLookup::class );
+		$lookup->expects( $this->any() )
+			->method( $this->anything() )
+			->willThrowException( $exception );
+		return $lookup;
+	}
+
+	public function testLookupExceptionsAreNotCaughtInGetEntity() {
+		$lookup = $this->getExceptionThrowingLookup( new EntityLookupException( new ItemId( 'Q321' ) ) );
+
+		$dispatchingLookup = new DispatchingEntityLookup( [ '' => $lookup ] );
+
+		$this->setExpectedException( EntityLookupException::class );
+		$dispatchingLookup->getEntity( new ItemId( 'Q321' ) );
+	}
+
+	public function testGivenEntityIdFromUnknownRepository_getEntityThrowsException() {
+		$dispatchingLookup = new DispatchingEntityLookup( [ '' => $this->getMock( EntityLookup::class ), ] );
+
+		$this->setExpectedException( UnknownForeignRepositoryException::class );
+
+		$dispatchingLookup->getEntity( new ItemId( 'foo:Q1' ) );
+	}
+
+	public function testGivenExistingEntityId_hasEntityReturnsTrue() {
+		$localLookup = new InMemoryEntityLookup();
+		$localLookup->addEntity( new FakeEntityDocument( new ItemId( 'Q1' ) ) );
+		$fooLookup = new InMemoryEntityLookup();
+		$fooLookup->addEntity( new FakeEntityDocument( new PropertyId( 'foo:P11' ) ) );
+
+		$dispatchingLookup = new DispatchingEntityLookup( [ '' => $localLookup, 'foo' => $fooLookup ] );
+
+		$this->assertTrue( $dispatchingLookup->hasEntity( new ItemId( 'Q1' ) ) );
+		$this->assertTrue( $dispatchingLookup->hasEntity( new PropertyId( 'foo:P11' ) ) );
+	}
+
+	public function testGivenNotExistingEntityIdFromKnownRepository_getEntityReturnsFalse() {
+		$localLookup = new InMemoryEntityLookup();
+		$fooLookup = new InMemoryEntityLookup();
+
+		$dispatchingLookup = new DispatchingEntityLookup( [ '' => $localLookup, 'foo' => $fooLookup ] );
+
+		$this->assertFalse( $dispatchingLookup->hasEntity( new ItemId( 'Q1' ) ) );
+		$this->assertFalse( $dispatchingLookup->hasEntity( new ItemId( 'foo:Q19' ) ) );
+	}
+
+	public function testLookupExceptionsAreNotCaughtInHasEntity() {
+		$lookup = $this->getExceptionThrowingLookup( new EntityLookupException( new ItemId( 'Q321' ) ) );
+
+		$dispatchingLookup = new DispatchingEntityLookup( [ '' => $lookup ] );
+
+		$this->setExpectedException( EntityLookupException::class );
+		$dispatchingLookup->hasEntity( new ItemId( 'Q321' ) );
+	}
+
+	public function testGivenEntityIdFromUnknownRepository_hasEntityThrowsException() {
+		$dispatchingLookup = new DispatchingEntityLookup( [ '' => $this->getMock( EntityLookup::class ), ] );
+
+		$this->setExpectedException( UnknownForeignRepositoryException::class );
+
+		$dispatchingLookup->hasEntity( new ItemId( 'foo:Q1' ) );
+	}
+
+}


### PR DESCRIPTION
DispatchingEntityLookup picks the right EntityLookup object to perform the lookup depending on the repository the input EntityId object is coming from.

Issues to be solved:
- how do we want to name such services (this is the first of the whole bunch): should they be "Multiplexing" services, or rather "Dispatching" services, or maybe something else? Any suggestions? - edit 12.10.2016: per Jeroen's suggestion "Dispatching" is used in the service name, not the original "Multiplexing"
- ~~depends on DM 6.2 which has not been tagged yet,~~
- ~~I am not quite sure how it should deal with the "main" repository, ie. how should it handle "local" EntityId (ie. not coming from the foreign repository). Should the constructor get a single "default" EntityLookup for all non-foreign EntityIds, and then a (possibly empty) list of repository speciific lookups? Or maybe rather should it expect to only get an array of lookups with special empty-string key reserved for the default lookup? The latter seems far more hacky, so I guess it is either the former approach or something even better I couldn't think of. Suggestions?~~
- to make review easier amendments to the original commit have been submitted as separate commits. They all need to be squashed into single commit before merging.

~~Note: this includes https://github.com/wmde/WikibaseDataModelServices/pull/150/commits/336a8341e7db350ec72b31696ea845167260daa8 from https://github.com/wmde/WikibaseDataModelServices/pull/154~~

Ticket: [T146989](https://phabricator.wikimedia.org/T146989)