### PR TITLE
Add DispatchingTermLookup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,13 @@ matrix:
   include:
     - env: DM=@dev
       php: 5.5
-    - env: DM=~6.0
+    - env: DM=~6.2
       php: 5.5
-    - env: DM=~6.0
+    - env: DM=~6.2
       php: 5.6
-    - env: DM=~5.0
+    - env: DM=~6.2
       php: 7
-    - env: DM=~4.2
+    - env: DM=~6.2
       php: hhvm
   exclude:
     - env: THENEEDFORTHIS=FAIL

--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,10 @@
 	},
 	"require": {
 		"php": ">=5.5.0",
-		"wikibase/data-model": "~6.0|~5.0|~4.2",
+		"wikibase/data-model": "~6.2",
 		"data-values/data-values": "~0.1|~1.0",
-		"diff/diff": "~2.0|~1.0"
+		"diff/diff": "~2.0|~1.0",
+		"wikimedia/assert": "~0.2.2"
 	},
 	"require-dev": {
 		"squizlabs/php_codesniffer": "~2.3",

--- a/src/Lookup/DispatchingTermLookup.php
+++ b/src/Lookup/DispatchingTermLookup.php
@@ -113,7 +113,7 @@ class DispatchingTermLookup implements TermLookup {
 	private function getLookupForEntityId( EntityId $entityId ) {
 		$repo = $entityId->getRepositoryName();
 		if ( !isset( $this->lookups[$repo] ) ) {
-			throw new UnknownForeignRepositoryException( $entityId->getRepositoryName() );
+			throw new UnknownForeignRepositoryException( $repo );
 		}
 		return $this->lookups[$repo];
 	}

--- a/src/Lookup/DispatchingTermLookup.php
+++ b/src/Lookup/DispatchingTermLookup.php
@@ -70,7 +70,7 @@ class DispatchingTermLookup implements TermLookup {
 	 * @throws TermLookupException
 	 * @throws UnknownForeignRepositoryException
 	 *
-	 * @return null|string
+	 * @return string[]
 	 */
 	public function getLabels( EntityId $entityId, array $languageCodes ) {
 		return $this->getLookupForEntityId( $entityId )->getLabels( $entityId, $languageCodes );
@@ -91,7 +91,6 @@ class DispatchingTermLookup implements TermLookup {
 		return $this->getLookupForEntityId( $entityId )->getDescription( $entityId, $languageCode );
 	}
 
-
 	/**
 	 * @see TermLookup::getDescriptions
 	 *
@@ -101,7 +100,7 @@ class DispatchingTermLookup implements TermLookup {
 	 * @throws TermLookupException
 	 * @throws UnknownForeignRepositoryException
 	 *
-	 * @return null|string
+	 * @return string[]
 	 */
 	public function getDescriptions( EntityId $entityId, array $languageCodes ) {
 		return $this->getLookupForEntityId( $entityId )->getDescriptions( $entityId, $languageCodes );
@@ -118,4 +117,5 @@ class DispatchingTermLookup implements TermLookup {
 		}
 		return $this->lookups[$repo];
 	}
+
 }

--- a/src/Lookup/DispatchingTermLookup.php
+++ b/src/Lookup/DispatchingTermLookup.php
@@ -113,7 +113,7 @@ class DispatchingTermLookup implements TermLookup {
 	private function getLookupForEntityId( EntityId $entityId ) {
 		$repo = $entityId->getRepositoryName();
 		if ( !isset( $this->lookups[$repo] ) ) {
-			throw new UnknownForeignRepositoryException( $entityId, 'Unknown repository: ' . $repo );
+			throw new UnknownForeignRepositoryException( $entityId );
 		}
 		return $this->lookups[$repo];
 	}

--- a/src/Lookup/DispatchingTermLookup.php
+++ b/src/Lookup/DispatchingTermLookup.php
@@ -23,8 +23,8 @@ class DispatchingTermLookup implements TermLookup {
 
 	/**
 	 * @param TermLookup[] $lookups associative array with repository names (strings) as keys
-	 *                                and TermLookup objects as values. Empty-string key
-	 *                                defines lookup for the local repository.
+	 *                              and TermLookup objects as values. Empty-string key
+	 *                              defines lookup for the local repository.
 	 *
 	 * @throws ParameterAssertionException
 	 */

--- a/src/Lookup/DispatchingTermLookup.php
+++ b/src/Lookup/DispatchingTermLookup.php
@@ -29,11 +29,7 @@ class DispatchingTermLookup implements TermLookup {
 	 * @throws ParameterAssertionException
 	 */
 	public function __construct( array $lookups ) {
-		Assert::parameter(
-			!empty( $lookups ) && array_key_exists( '', $lookups ),
-			'$lookups',
-			'must must not be empty and must contain an empty-string key'
-		);
+		Assert::parameter( !empty( $lookups ), '$lookups', 'must must not be empty' );
 		Assert::parameterElementType( TermLookup::class, $lookups, '$lookups' );
 		Assert::parameterElementType( 'string', array_keys( $lookups ), 'array_keys( $lookups )' );
 		foreach ( array_keys( $lookups ) as $repositoryName ) {

--- a/src/Lookup/DispatchingTermLookup.php
+++ b/src/Lookup/DispatchingTermLookup.php
@@ -113,7 +113,7 @@ class DispatchingTermLookup implements TermLookup {
 	private function getLookupForEntityId( EntityId $entityId ) {
 		$repo = $entityId->getRepositoryName();
 		if ( !isset( $this->lookups[$repo] ) ) {
-			throw new UnknownForeignRepositoryException( $entityId );
+			throw new UnknownForeignRepositoryException( $entityId->getRepositoryName() );
 		}
 		return $this->lookups[$repo];
 	}

--- a/src/Lookup/DispatchingTermLookup.php
+++ b/src/Lookup/DispatchingTermLookup.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Lookup;
+
+use Wikibase\DataModel\Entity\EntityId;
+use Wikimedia\Assert\Assert;
+use Wikimedia\Assert\ParameterAssertionException;
+
+/**
+ * Wrapper around repository-specific TermLookups
+ * picking up the right lookup object for the particular input.
+ *
+ * @since 3.7
+ *
+ * @license GPL-2.0+
+ */
+class DispatchingTermLookup implements TermLookup {
+
+	/**
+	 * @var TermLookup[]
+	 */
+	private $lookups;
+
+	/**
+	 * @param TermLookup[] $lookups associative array with repository names (strings) as keys
+	 *                                and TermLookup objects as values. Empty-string key
+	 *                                defines lookup for the local repository.
+	 *
+	 * @throws ParameterAssertionException
+	 */
+	public function __construct( array $lookups ) {
+		Assert::parameter(
+			!empty( $lookups ) && array_key_exists( '', $lookups ),
+			'$lookups',
+			'must must not be empty and must contain an empty-string key'
+		);
+		Assert::parameterElementType( TermLookup::class, $lookups, '$lookups' );
+		Assert::parameterElementType( 'string', array_keys( $lookups ), 'array_keys( $lookups )' );
+		foreach ( array_keys( $lookups ) as $repositoryName ) {
+			Assert::parameter(
+				strpos( $repositoryName, ':' ) === false,
+				'array_keys( $lookups )',
+				'must not contain strings including colons'
+			);
+		}
+		$this->lookups = $lookups;
+	}
+
+	/**
+	 * @see TermLookup::getLabel
+	 *
+	 * @param EntityId $entityId
+	 * @param string $languageCode
+	 *
+	 * @throws TermLookupException
+	 * @throws UnknownForeignRepositoryException
+	 *
+	 * @return null|string
+	 */
+	public function getLabel( EntityId $entityId, $languageCode ) {
+		return $this->getLookupForEntityId( $entityId )->getLabel( $entityId, $languageCode );
+	}
+
+	/**
+	 * @see TermLookup::getLabels
+	 *
+	 * @param EntityId $entityId
+	 * @param string[] $languageCodes
+	 *
+	 * @throws TermLookupException
+	 * @throws UnknownForeignRepositoryException
+	 *
+	 * @return null|string
+	 */
+	public function getLabels( EntityId $entityId, array $languageCodes ) {
+		return $this->getLookupForEntityId( $entityId )->getLabels( $entityId, $languageCodes );
+	}
+
+	/**
+	 * @see TermLookup::getDescription
+	 *
+	 * @param EntityId $entityId
+	 * @param string $languageCode
+	 *
+	 * @throws TermLookupException
+	 * @throws UnknownForeignRepositoryException
+	 *
+	 * @return null|string
+	 */
+	public function getDescription( EntityId $entityId, $languageCode ) {
+		return $this->getLookupForEntityId( $entityId )->getDescription( $entityId, $languageCode );
+	}
+
+
+	/**
+	 * @see TermLookup::getDescriptions
+	 *
+	 * @param EntityId $entityId
+	 * @param string[] $languageCodes
+	 *
+	 * @throws TermLookupException
+	 * @throws UnknownForeignRepositoryException
+	 *
+	 * @return null|string
+	 */
+	public function getDescriptions( EntityId $entityId, array $languageCodes ) {
+		return $this->getLookupForEntityId( $entityId )->getDescriptions( $entityId, $languageCodes );
+	}
+
+	/**
+	 * @param EntityId $entityId
+	 * @return TermLookup
+	 */
+	private function getLookupForEntityId( EntityId $entityId ) {
+		$repo = $entityId->getRepositoryName();
+		if ( !isset( $this->lookups[$repo] ) ) {
+			throw new UnknownForeignRepositoryException( $entityId, 'Unknown repository: ' . $repo );
+		}
+		return $this->lookups[$repo];
+	}
+}

--- a/tests/unit/Lookup/DispatchingTermLookupTest.php
+++ b/tests/unit/Lookup/DispatchingTermLookupTest.php
@@ -25,9 +25,6 @@ class DispatchingTermLookupTest extends \PHPUnit_Framework_TestCase {
 	public function provideInvalidForeignLookups() {
 		return [
 			'no lookups given' => [[]],
-			'no lookup given for the local repository' => [
-				[ 'foo' => $this->getMock( TermLookup::class ), ]
-			],
 			'not an implementation of TermLookup given as a lookup' => [
 				[ '' => new ItemId( 'Q123' ) ],
 			],
@@ -69,134 +66,110 @@ class DispatchingTermLookupTest extends \PHPUnit_Framework_TestCase {
 		];
 	}
 
-	public function testGetLabelFromLocalRepo() {
-		$localLookup = $this->getMock( TermLookup::class );
-		$localLookup->expects( $this->once() )
+	public function testGetLabel() {
+		$lookup1 = $this->getMock( TermLookup::class );
+		$lookup1->expects( $this->once() )
 			->method( 'getLabel' )
-			->willReturn( 'label' );
+			->willReturn( 'label1' );
+
+		$lookup2 = $this->getMock( TermLookup::class );
+		$lookup2->expects( $this->once() )
+			->method( 'getLabel' )
+			->willReturn( 'label2' );
+
 		$dispatcher = new DispatchingTermLookup( [
-			'' => $localLookup,
-			'foo' => $this->getMock( TermLookup::class ),
+			'' => $lookup1,
+			'foo' => $lookup2,
 		] );
 
 		$this->assertSame(
-			'label',
+			'label1',
 			$dispatcher->getLabel( new ItemId( 'Q123' ), 'en' )
 		);
-	}
-
-	public function testGetLabelFromForeignRepo() {
-		$foreignLookup = $this->getMock( TermLookup::class );
-		$foreignLookup->expects( $this->once() )
-			->method( 'getLabel' )
-			->willReturn( 'label' );
-		$dispatcher = new DispatchingTermLookup( [
-			'' => $this->getMock( TermLookup::class ),
-			'foo' => $foreignLookup,
-		] );
-
 		$this->assertSame(
-			'label',
+			'label2',
 			$dispatcher->getLabel( new ItemId( 'foo:Q123' ), 'en' )
 		);
 	}
 
-	public function testGetLabelsFromLocalRepo() {
-		$labels = [ 'en' => 'enLabel', 'fr' => 'frLabel' ];
-		$localLookup = $this->getMock( TermLookup::class );
-		$localLookup->expects( $this->once() )
+	public function testGetLabels() {
+		$labels1 = [ 'en' => 'enLabel1', 'fr' => 'frLabel1' ];
+		$lookup1 = $this->getMock( TermLookup::class );
+		$lookup1->expects( $this->once() )
 			->method( 'getLabels' )
-			->willReturn( $labels );
+			->willReturn( $labels1 );
+
+		$labels2 = [ 'en' => 'enLabel2', 'fr' => 'frLabel2' ];
+		$lookup2 = $this->getMock( TermLookup::class );
+		$lookup2->expects( $this->once() )
+			->method( 'getLabels' )
+			->willReturn( $labels2 );
+
 		$dispatcher = new DispatchingTermLookup( [
-			'' => $localLookup,
-			'foo' => $this->getMock( TermLookup::class ),
+			'' => $lookup1,
+			'foo' => $lookup2,
 		] );
 
 		$this->assertSame(
-			$labels,
+			$labels1,
 			$dispatcher->getLabels( new ItemId( 'Q123' ), [ 'en', 'fr' ] )
 		);
-	}
-
-	public function testGetLabelsFromForeignRepo() {
-		$labels = [ 'en' => 'enLabel', 'fr' => 'frLabel' ];
-		$foreignLookup = $this->getMock( TermLookup::class );
-		$foreignLookup->expects( $this->once() )
-			->method( 'getLabels' )
-			->willReturn( $labels );
-		$dispatcher = new DispatchingTermLookup( [
-			'' => $this->getMock( TermLookup::class ),
-			'foo' => $foreignLookup,
-		] );
-
 		$this->assertSame(
-			$labels,
+			$labels2,
 			$dispatcher->getLabels( new ItemId( 'foo:Q123' ), [ 'en', 'fr' ] )
 		);
 	}
 
-	public function testGetDescriptionFromLocalRepo() {
-		$localLookup = $this->getMock( TermLookup::class );
-		$localLookup->expects( $this->once() )
+	public function testGetDescription() {
+		$lookup1 = $this->getMock( TermLookup::class );
+		$lookup1->expects( $this->once() )
 			->method( 'getDescription' )
-			->willReturn( 'description' );
+			->willReturn( 'description1' );
+
+		$lookup2 = $this->getMock( TermLookup::class );
+		$lookup2->expects( $this->once() )
+			->method( 'getDescription' )
+			->willReturn( 'description2' );
+
 		$dispatcher = new DispatchingTermLookup( [
-			'' => $localLookup,
-			'foo' => $this->getMock( TermLookup::class ),
+			'' => $lookup1,
+			'foo' => $lookup2,
 		] );
 
 		$this->assertSame(
-			'description',
+			'description1',
 			$dispatcher->getDescription( new ItemId( 'Q123' ), 'en' )
 		);
-	}
-
-	public function testGetDescriptionFromForeignRepo() {
-		$foreignLookup = $this->getMock( TermLookup::class );
-		$foreignLookup->expects( $this->once() )
-			->method( 'getDescription' )
-			->willReturn( 'description' );
-		$dispatcher = new DispatchingTermLookup( [
-			'' => $this->getMock( TermLookup::class ),
-			'foo' => $foreignLookup,
-		] );
-
 		$this->assertSame(
-			'description',
+			'description2',
 			$dispatcher->getDescription( new ItemId( 'foo:Q123' ), 'en' )
 		);
 	}
 
-	public function testGetDescriptionsFromLocalRepo() {
-		$descriptions = [ 'en' => 'description' ];
-		$localLookup = $this->getMock( TermLookup::class );
-		$localLookup->expects( $this->once() )
+	public function testGetDescriptions() {
+		$descriptions1 = [ 'en' => 'description1' ];
+		$lookup1 = $this->getMock( TermLookup::class );
+		$lookup1->expects( $this->once() )
 			->method( 'getDescriptions' )
-			->willReturn( $descriptions );
+			->willReturn( $descriptions1 );
+
+		$descriptions2 = [ 'en' => 'description2' ];
+		$lookup2 = $this->getMock( TermLookup::class );
+		$lookup2->expects( $this->once() )
+			->method( 'getDescriptions' )
+			->willReturn( $descriptions2 );
+
 		$dispatcher = new DispatchingTermLookup( [
-			'' => $localLookup,
-			'foo' => $this->getMock( TermLookup::class ),
+			'' => $lookup1,
+			'foo' => $lookup2,
 		] );
 
 		$this->assertSame(
-			$descriptions,
+			$descriptions1,
 			$dispatcher->getDescriptions( new ItemId( 'Q123' ), [ 'en' ] )
 		);
-	}
-
-	public function testGetDescriptionsFromForeignRepo() {
-		$descriptions = [ 'en' => 'description' ];
-		$foreignLookup = $this->getMock( TermLookup::class );
-		$foreignLookup->expects( $this->once() )
-			->method( 'getDescriptions' )
-			->willReturn( $descriptions );
-		$dispatcher = new DispatchingTermLookup( [
-			'' => $this->getMock( TermLookup::class ),
-			'foo' => $foreignLookup,
-		] );
-
 		$this->assertSame(
-			$descriptions,
+			$descriptions2,
 			$dispatcher->getDescriptions( new ItemId( 'foo:Q123' ), [ 'en' ] )
 		);
 	}

--- a/tests/unit/Lookup/DispatchingTermLookupTest.php
+++ b/tests/unit/Lookup/DispatchingTermLookupTest.php
@@ -1,10 +1,12 @@
 <?php
 namespace Wikibase\DataModel\Services\Tests\Lookup;
+
 use Wikibase\DataModel\Entity\ItemId;
 use Wikibase\DataModel\Services\Lookup\DispatchingTermLookup;
 use Wikibase\DataModel\Services\Lookup\TermLookup;
 use Wikibase\DataModel\Services\Lookup\UnknownForeignRepositoryException;
 use Wikimedia\Assert\ParameterAssertionException;
+
 /**
  * @covers Wikibase\DataModel\Services\Lookup\DispatchingTermLookup
  *

--- a/tests/unit/Lookup/DispatchingTermLookupTest.php
+++ b/tests/unit/Lookup/DispatchingTermLookupTest.php
@@ -71,90 +71,134 @@ class DispatchingTermLookupTest extends \PHPUnit_Framework_TestCase {
 
 	public function testGetLabelFromLocalRepo() {
 		$localLookup = $this->getMock( TermLookup::class );
-		$localLookup->expects( $this->once() )->method( 'getLabel' );
+		$localLookup->expects( $this->once() )
+			->method( 'getLabel' )
+			->willReturn( 'label' );
 		$dispatcher = new DispatchingTermLookup( [
 			'' => $localLookup,
 			'foo' => $this->getMock( TermLookup::class ),
 		] );
 
-		$dispatcher->getLabel( new ItemId( 'Q123' ), 'en' );
+		$this->assertSame(
+			'label',
+			$dispatcher->getLabel( new ItemId( 'Q123' ), 'en' )
+		);
 	}
 
 	public function testGetLabelFromForeignRepo() {
 		$foreignLookup = $this->getMock( TermLookup::class );
-		$foreignLookup->expects( $this->once() )->method( 'getLabel' );
+		$foreignLookup->expects( $this->once() )
+			->method( 'getLabel' )
+			->willReturn( 'label' );
 		$dispatcher = new DispatchingTermLookup( [
 			'' => $this->getMock( TermLookup::class ),
 			'foo' => $foreignLookup,
 		] );
 
-		$dispatcher->getLabel( new ItemId( 'foo:Q123' ), 'en' );
+		$this->assertSame(
+			'label',
+			$dispatcher->getLabel( new ItemId( 'foo:Q123' ), 'en' )
+		);
 	}
 
 	public function testGetLabelsFromLocalRepo() {
+		$labels = [ 'en' => 'enLabel', 'fr' => 'frLabel' ];
 		$localLookup = $this->getMock( TermLookup::class );
-		$localLookup->expects( $this->once() )->method( 'getLabels' );
+		$localLookup->expects( $this->once() )
+			->method( 'getLabels' )
+			->willReturn( $labels );
 		$dispatcher = new DispatchingTermLookup( [
 			'' => $localLookup,
 			'foo' => $this->getMock( TermLookup::class ),
 		] );
 
-		$dispatcher->getLabels( new ItemId( 'Q123' ), [ 'en' ] );
+		$this->assertSame(
+			$labels,
+			$dispatcher->getLabels( new ItemId( 'Q123' ), [ 'en', 'fr' ] )
+		);
 	}
 
 	public function testGetLabelsFromForeignRepo() {
+		$labels = [ 'en' => 'enLabel', 'fr' => 'frLabel' ];
 		$foreignLookup = $this->getMock( TermLookup::class );
-		$foreignLookup->expects( $this->once() )->method( 'getLabels' );
+		$foreignLookup->expects( $this->once() )
+			->method( 'getLabels' )
+			->willReturn( $labels );
 		$dispatcher = new DispatchingTermLookup( [
 			'' => $this->getMock( TermLookup::class ),
 			'foo' => $foreignLookup,
 		] );
 
-		$dispatcher->getLabels( new ItemId( 'foo:Q123' ), [ 'en' ] );
+		$this->assertSame(
+			$labels,
+			$dispatcher->getLabels( new ItemId( 'foo:Q123' ), [ 'en', 'fr' ] )
+		);
 	}
 
 	public function testGetDescriptionFromLocalRepo() {
 		$localLookup = $this->getMock( TermLookup::class );
-		$localLookup->expects( $this->once() )->method( 'getDescription' );
+		$localLookup->expects( $this->once() )
+			->method( 'getDescription' )
+			->willReturn( 'description' );
 		$dispatcher = new DispatchingTermLookup( [
 			'' => $localLookup,
 			'foo' => $this->getMock( TermLookup::class ),
 		] );
 
-		$dispatcher->getDescription( new ItemId( 'Q123' ), 'en' );
+		$this->assertSame(
+			'description',
+			$dispatcher->getDescription( new ItemId( 'Q123' ), 'en' )
+		);
 	}
 
 	public function testGetDescriptionFromForeignRepo() {
 		$foreignLookup = $this->getMock( TermLookup::class );
-		$foreignLookup->expects( $this->once() )->method( 'getDescription' );
+		$foreignLookup->expects( $this->once() )
+			->method( 'getDescription' )
+			->willReturn( 'description' );
 		$dispatcher = new DispatchingTermLookup( [
 			'' => $this->getMock( TermLookup::class ),
 			'foo' => $foreignLookup,
 		] );
 
-		$dispatcher->getDescription( new ItemId( 'foo:Q123' ), 'en' );
+		$this->assertSame(
+			'description',
+			$dispatcher->getDescription( new ItemId( 'foo:Q123' ), 'en' )
+		);
 	}
 
 	public function testGetDescriptionsFromLocalRepo() {
+		$descriptions = [ 'en' => 'description' ];
 		$localLookup = $this->getMock( TermLookup::class );
-		$localLookup->expects( $this->once() )->method( 'getDescriptions' );
+		$localLookup->expects( $this->once() )
+			->method( 'getDescriptions' )
+			->willReturn( $descriptions );
 		$dispatcher = new DispatchingTermLookup( [
 			'' => $localLookup,
 			'foo' => $this->getMock( TermLookup::class ),
 		] );
 
-		$dispatcher->getDescriptions( new ItemId( 'Q123' ), [ 'en' ] );
+		$this->assertSame(
+			$descriptions,
+			$dispatcher->getDescriptions( new ItemId( 'Q123' ), [ 'en' ] )
+		);
 	}
 
 	public function testGetDescriptionsFromForeignRepo() {
+		$descriptions = [ 'en' => 'description' ];
 		$foreignLookup = $this->getMock( TermLookup::class );
-		$foreignLookup->expects( $this->once() )->method( 'getDescriptions' );
+		$foreignLookup->expects( $this->once() )
+			->method( 'getDescriptions' )
+			->willReturn( $descriptions );
 		$dispatcher = new DispatchingTermLookup( [
 			'' => $this->getMock( TermLookup::class ),
 			'foo' => $foreignLookup,
 		] );
 
-		$dispatcher->getDescriptions( new ItemId( 'foo:Q123' ), [ 'en' ] );
+		$this->assertSame(
+			$descriptions,
+			$dispatcher->getDescriptions( new ItemId( 'foo:Q123' ), [ 'en' ] )
+		);
 	}
 
 }

--- a/tests/unit/Lookup/DispatchingTermLookupTest.php
+++ b/tests/unit/Lookup/DispatchingTermLookupTest.php
@@ -1,0 +1,158 @@
+<?php
+namespace Wikibase\DataModel\Services\Tests\Lookup;
+use Wikibase\DataModel\Entity\ItemId;
+use Wikibase\DataModel\Services\Lookup\DispatchingTermLookup;
+use Wikibase\DataModel\Services\Lookup\TermLookup;
+use Wikibase\DataModel\Services\Lookup\UnknownForeignRepositoryException;
+use Wikimedia\Assert\ParameterAssertionException;
+/**
+ * @covers Wikibase\DataModel\Services\Lookup\DispatchingTermLookup
+ *
+ * @license GPL-2.0+
+ */
+class DispatchingTermLookupTest extends \PHPUnit_Framework_TestCase {
+
+	/**
+	 * @dataProvider provideInvalidForeignLookups
+	 */
+	public function testGivenInvalidForeignLookups_exceptionIsThrown( array $lookups ) {
+		$this->setExpectedException( ParameterAssertionException::class );
+		new DispatchingTermLookup( $lookups );
+	}
+
+	public function provideInvalidForeignLookups() {
+		return [
+			'no lookups given' => [[]],
+			'no lookup given for the local repository' => [
+				[ 'foo' => $this->getMock( TermLookup::class ), ]
+			],
+			'not an implementation of TermLookup given as a lookup' => [
+				[ '' => new ItemId( 'Q123' ) ],
+			],
+			'non-string keys' => [
+				[
+					'' => $this->getMock( TermLookup::class ),
+					100 => $this->getMock( TermLookup::class ),
+				],
+			],
+			'repo name containing colon' => [
+				[
+					'' => $this->getMock( TermLookup::class ),
+					'fo:oo' => $this->getMock( TermLookup::class ),
+				],
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider publicMethodsProvider
+	 */
+	public function testGivenEntityFromUnknownRepo_throwsException( $method, $language ) {
+		$item = new ItemId( 'fooo:Q123' );
+		$lookup = new DispatchingTermLookup( [
+			'' => $this->getMock( TermLookup::class ),
+			'foo' => $this->getMock( TermLookup::class ),
+		] );
+
+		$this->setExpectedException( UnknownForeignRepositoryException::class );
+		$lookup->$method( $item, $language );
+	}
+
+	public function publicMethodsProvider() {
+		return [
+			[ 'getLabel', 'en' ],
+			[ 'getLabels', [ 'en', 'fr' ] ],
+			[ 'getDescription', 'en' ],
+			[ 'getDescription', [ 'en', 'de' ] ],
+		];
+	}
+
+	public function testGetLabelFromLocalRepo() {
+		$localLookup = $this->getMock( TermLookup::class );
+		$localLookup->expects( $this->once() )->method( 'getLabel' );
+		$dispatcher = new DispatchingTermLookup( [
+			'' => $localLookup,
+			'foo' => $this->getMock( TermLookup::class ),
+		] );
+
+		$dispatcher->getLabel( new ItemId( 'Q123' ), 'en' );
+	}
+
+	public function testGetLabelFromForeignRepo() {
+		$foreignLookup = $this->getMock( TermLookup::class );
+		$foreignLookup->expects( $this->once() )->method( 'getLabel' );
+		$dispatcher = new DispatchingTermLookup( [
+			'' => $this->getMock( TermLookup::class ),
+			'foo' => $foreignLookup,
+		] );
+
+		$dispatcher->getLabel( new ItemId( 'foo:Q123' ), 'en' );
+	}
+
+	public function testGetLabelsFromLocalRepo() {
+		$localLookup = $this->getMock( TermLookup::class );
+		$localLookup->expects( $this->once() )->method( 'getLabels' );
+		$dispatcher = new DispatchingTermLookup( [
+			'' => $localLookup,
+			'foo' => $this->getMock( TermLookup::class ),
+		] );
+
+		$dispatcher->getLabels( new ItemId( 'Q123' ), [ 'en' ] );
+	}
+
+	public function testGetLabelsFromForeignRepo() {
+		$foreignLookup = $this->getMock( TermLookup::class );
+		$foreignLookup->expects( $this->once() )->method( 'getLabels' );
+		$dispatcher = new DispatchingTermLookup( [
+			'' => $this->getMock( TermLookup::class ),
+			'foo' => $foreignLookup,
+		] );
+
+		$dispatcher->getLabels( new ItemId( 'foo:Q123' ), [ 'en' ] );
+	}
+
+	public function testGetDescriptionFromLocalRepo() {
+		$localLookup = $this->getMock( TermLookup::class );
+		$localLookup->expects( $this->once() )->method( 'getDescription' );
+		$dispatcher = new DispatchingTermLookup( [
+			'' => $localLookup,
+			'foo' => $this->getMock( TermLookup::class ),
+		] );
+
+		$dispatcher->getDescription( new ItemId( 'Q123' ), 'en' );
+	}
+
+	public function testGetDescriptionFromForeignRepo() {
+		$foreignLookup = $this->getMock( TermLookup::class );
+		$foreignLookup->expects( $this->once() )->method( 'getDescription' );
+		$dispatcher = new DispatchingTermLookup( [
+			'' => $this->getMock( TermLookup::class ),
+			'foo' => $foreignLookup,
+		] );
+
+		$dispatcher->getDescription( new ItemId( 'foo:Q123' ), 'en' );
+	}
+
+	public function testGetDescriptionsFromLocalRepo() {
+		$localLookup = $this->getMock( TermLookup::class );
+		$localLookup->expects( $this->once() )->method( 'getDescriptions' );
+		$dispatcher = new DispatchingTermLookup( [
+			'' => $localLookup,
+			'foo' => $this->getMock( TermLookup::class ),
+		] );
+
+		$dispatcher->getDescriptions( new ItemId( 'Q123' ), [ 'en' ] );
+	}
+
+	public function testGetDescriptionsFromForeignRepo() {
+		$foreignLookup = $this->getMock( TermLookup::class );
+		$foreignLookup->expects( $this->once() )->method( 'getDescriptions' );
+		$dispatcher = new DispatchingTermLookup( [
+			'' => $this->getMock( TermLookup::class ),
+			'foo' => $foreignLookup,
+		] );
+
+		$dispatcher->getDescriptions( new ItemId( 'foo:Q123' ), [ 'en' ] );
+	}
+
+}


### PR DESCRIPTION
- adds a service that picks a `TermLookup` for the corresponding repository for a given `EntityId`
- implemented on top of #150 in order to reuse `UnknownForeignRepositoryException`

Task on Phabricator: https://phabricator.wikimedia.org/T149583