### PR TITLE
Add functions to assert a value is an allowable repository name, or an array indexed by repository names

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
 		"php": ">=5.5.0",
 		"wikibase/data-model": "~6.0|~5.0|~4.2",
 		"data-values/data-values": "~0.1|~1.0",
-		"diff/diff": "~2.0|~1.0"
+		"diff/diff": "~2.0|~1.0",
+		"wikimedia/assert": "~0.2.2"
 	},
 	"require-dev": {
 		"squizlabs/php_codesniffer": "~2.3",

--- a/src/Assert/Assert.php
+++ b/src/Assert/Assert.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Assert;
+
+use Wikimedia\Assert\Assert as WikimediaAssert;
+use Wikimedia\Assert\ParameterAssertionException;
+
+/**
+ * Provides functions to assure values meet certain preconditions relevant
+ * in Wikibase.
+ *
+ * @see Wikimedia\Assert\Assert
+ *
+ * @since 3.7
+ *
+ * @license GPL-2.0+
+ */
+class Assert {
+
+	/**
+	 * @param string $value
+	 * @param string $name
+	 *
+	 * @throws ParameterAssertionException if $value is not an allowable repository name.
+	 */
+	public static function parameterIsAllowableRepositoryName( $value, $name ) {
+		if ( !self::isAllowableRepositoryName( $value ) ) {
+			throw new ParameterAssertionException( $name, 'must be a string not including colons' );
+		}
+	}
+
+	/**
+	 * @param array $value
+	 * @param string $name
+	 *
+	 * @throws ParameterAssertionException If an element of $value is not
+	 *         an allowable repository name.
+	 */
+	public static function parameterKeyIsAllowableRepositoryName( $value, $name ) {
+		WikimediaAssert::parameterType( 'array', $value, $name );
+		// TODO: change to Assert::parameterKeyType when the new version of the library is released
+		WikimediaAssert::parameterElementType( 'string', array_keys( $value ), "array_keys( $name )" );
+
+		foreach ( array_keys( $value ) as $key ) {
+			if ( !self::isAllowableRepositoryName( $key ) ) {
+				throw new ParameterAssertionException(
+					"array_keys( $name )",
+					'must not contain strings including colons'
+				);
+			}
+		}
+	}
+
+	/**
+	 * @param string $value
+	 * @return bool
+	 */
+	private static function isAllowableRepositoryName( $value ) {
+		return is_string( $value ) && strpos( $value, ':' ) === false;
+	}
+
+}

--- a/tests/unit/Assert/AssertTest.php
+++ b/tests/unit/Assert/AssertTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Tests\Assert;
+
+use Wikibase\DataModel\Services\Assert\Assert;
+use Wikimedia\Assert\ParameterAssertionException;
+
+/**
+ * @covers Wikibase\DataModel\Services\Assert\Assert
+ *
+ * @license GPL-2.0+
+ */
+class AssertTest extends \PHPUnit_Framework_TestCase {
+
+	public function provideNotAllowableRepositoryNames() {
+		return array(
+			array( 'fo:o' ),
+			array( 'foo:' ),
+			array( ':foo' ),
+			array( ':' ),
+			array( 123 ),
+			array( null ),
+			array( false ),
+			array( array( 'foo' ) ),
+		);
+	}
+
+	/**
+	 * @dataProvider provideNotAllowableRepositoryNames
+	 */
+	public function testGivenInvalidValue_parameterIsAllowableRepositoryNameFails( $value ) {
+		$this->setExpectedException( ParameterAssertionException::class );
+		Assert::parameterIsAllowableRepositoryName( $value, 'test' );
+	}
+
+	public function provideAllowableRepositoryNames() {
+		return array(
+			array( '' ),
+			array( 'foo' ),
+			array( '123' ),
+		);
+	}
+
+	/**
+	 * @dataProvider provideAllowableRepositoryNames
+	 */
+	public function testGivenValidValue_parameterIsAllowableRepositoryNamePasses( $value ) {
+		Assert::parameterIsAllowableRepositoryName( $value, 'test' );
+	}
+
+	public function provideInvalidRepositoryNameIndexedArrays() {
+		return array(
+			array( 'foo' ),
+			array( array( 0 => 'foo' ) ),
+			array( array( 'fo:0' => 'bar' ) ),
+			array( array( 'foo:' => 'bar' ) ),
+			array( array( ':foo' => 'bar' ) ),
+		);
+	}
+
+	/**
+	 * @dataProvider provideInvalidRepositoryNameIndexedArrays
+	 */
+	public function testGivenInvalidValue_parameterKeyIsAllowableRepositoryNameFails( $value ) {
+		$this->setExpectedException( ParameterAssertionException::class );
+		Assert::parameterKeyIsAllowableRepositoryName( $value, 'test' );
+	}
+
+	public function provideValidRepositoryNameIndexedArrays() {
+		return array(
+			array( array( 'foo' => 'bar' ) ),
+			array( array( '' => 'bar' ) ),
+			array( array( '' => 'bar', 'foo' => 'baz' ) ),
+			array( array() ),
+		);
+	}
+
+	/**
+	 * @dataProvider provideValidRepositoryNameIndexedArrays
+	 */
+	public function testGivenValidValue_parameterKeyIsAllowableRepositoryNamePasses( $value ) {
+		Assert::parameterKeyIsAllowableRepositoryName( $value, 'test' );
+	}
+
+}


### PR DESCRIPTION
Such checks have been done in https://github.com/wmde/WikibaseDataModelServices/pull/150, https://github.com/wmde/WikibaseDataModelServices/pull/151 or https://gerrit.wikimedia.org/r/#/c/314682/, as well as in https://github.com/wmde/WikibaseDataModelServices/pull/146 and https://github.com/wmde/WikibaseDataModelServices/pull/149. Let's have a dedicated function/functions for this.

I am not sure about the name/location of the new class, and function names are horrible. Suggestions would be great!

Also I don't know if we want to have dedicated exception(s) for those rather special cases.