### PR TITLE
Restore PHPUnit compatibility

### DIFF
--- a/tests/unit/Lookup/DispatchingEntityLookupTest.php
+++ b/tests/unit/Lookup/DispatchingEntityLookupTest.php
@@ -72,13 +72,14 @@ class DispatchingEntityLookupTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @param Exception $exception
-	 * @return \PHPUnit_Framework_MockObject_MockObject|EntityLookup
+	 *
+	 * @return EntityLookup
 	 */
 	private function getExceptionThrowingLookup( Exception $exception ) {
 		$lookup = $this->getMock( EntityLookup::class );
 		$lookup->expects( $this->any() )
 			->method( $this->anything() )
-			->willThrowException( $exception );
+			->will( $this->throwException( $exception ) );
 		return $lookup;
 	}
 


### PR DESCRIPTION
This is a feature from a newer PHPUnit version. This line alone does not justify requiring a newer version.