### PR TITLE
Replace BasicEntityIdParser with ItemIdParser in tests

### DIFF
--- a/tests/unit/Statement/StatementGuidParserTest.php
+++ b/tests/unit/Statement/StatementGuidParserTest.php
@@ -2,8 +2,8 @@
 
 namespace Wikibase\DataModel\Services\Tests\Statement;
 
-use Wikibase\DataModel\Entity\BasicEntityIdParser;
 use Wikibase\DataModel\Entity\ItemId;
+use Wikibase\DataModel\Entity\ItemIdParser;
 use Wikibase\DataModel\Services\Statement\StatementGuidParser;
 use Wikibase\DataModel\Statement\StatementGuid;
 
@@ -24,8 +24,8 @@ class StatementGuidParserTest extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals( $actual, $expected );
 	}
 
-	protected function newParser() {
-		return new StatementGuidParser( new BasicEntityIdParser() );
+	private function newParser() {
+		return new StatementGuidParser( new ItemIdParser() );
 	}
 
 	public function guidProvider() {

--- a/tests/unit/Statement/StatementGuidValidatorTest.php
+++ b/tests/unit/Statement/StatementGuidValidatorTest.php
@@ -2,7 +2,7 @@
 
 namespace Wikibase\DataModel\Services\Tests\Statement;
 
-use Wikibase\DataModel\Entity\BasicEntityIdParser;
+use Wikibase\DataModel\Entity\ItemIdParser;
 use Wikibase\DataModel\Services\Statement\StatementGuidValidator;
 
 /**
@@ -13,9 +13,8 @@ use Wikibase\DataModel\Services\Statement\StatementGuidValidator;
  */
 class StatementGuidValidatorTest extends \PHPUnit_Framework_TestCase {
 
-	protected function newStatementGuidValidator() {
-		$entityIdParser = new BasicEntityIdParser();
-		return new StatementGuidValidator( $entityIdParser );
+	private function newStatementGuidValidator() {
+		return new StatementGuidValidator( new ItemIdParser() );
 	}
 
 	/**


### PR DESCRIPTION
Both these tests are using items only. Which is fine. No need to do an integration test with other entity types here. The idea of this patch is to simplify the test setup a little bit.