### PR TITLE
Introduce LabelLookup interface

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,9 @@
 # Wikibase DataModel Services release notes
 
+## Version 3.10.0 (dev)
+
+* Added `LabelLookup` interface.
+
 ## Version 3.9.0 (2018-01-18)
 
 * Added `EntityIdComposer`.

--- a/src/EntityId/EntityIdLabelFormatter.php
+++ b/src/EntityId/EntityIdLabelFormatter.php
@@ -3,8 +3,8 @@
 namespace Wikibase\DataModel\Services\EntityId;
 
 use Wikibase\DataModel\Entity\EntityId;
-use Wikibase\DataModel\Services\Lookup\LabelDescriptionLookup;
 use Wikibase\DataModel\Services\Lookup\LabelDescriptionLookupException;
+use Wikibase\DataModel\Services\Lookup\LabelLookup;
 use Wikibase\DataModel\Term\Term;
 
 /**
@@ -18,12 +18,12 @@ use Wikibase\DataModel\Term\Term;
 class EntityIdLabelFormatter implements EntityIdFormatter {
 
 	/**
-	 * @var LabelDescriptionLookup
+	 * @var LabelLookup
 	 */
-	private $labelDescriptionLookup;
+	private $labelLookup;
 
-	public function __construct( LabelDescriptionLookup $labelDescriptionLookup ) {
-		$this->labelDescriptionLookup = $labelDescriptionLookup;
+	public function __construct( LabelLookup $labelLookup ) {
+		$this->labelLookup = $labelLookup;
 	}
 
 	/**
@@ -44,15 +44,13 @@ class EntityIdLabelFormatter implements EntityIdFormatter {
 	}
 
 	/**
-	 * Lookup a label for an entity
-	 *
 	 * @param EntityId $entityId
 	 *
 	 * @return Term|null Null if no label was found or the entity does not exist
 	 */
 	protected function lookupEntityLabel( EntityId $entityId ) {
 		try {
-			return $this->labelDescriptionLookup->getLabel( $entityId );
+			return $this->labelLookup->getLabel( $entityId );
 		} catch ( LabelDescriptionLookupException $e ) {
 			return null;
 		}

--- a/src/Lookup/LabelLookup.php
+++ b/src/Lookup/LabelLookup.php
@@ -6,22 +6,19 @@ use Wikibase\DataModel\Entity\EntityId;
 use Wikibase\DataModel\Term\Term;
 
 /**
- * @since 1.1
+ * @since 3.10
  *
- * @license GPL-2.0+
- * @author Katie Filbert < aude.wiki@gmail.com >
- * @author Marius Hoch < hoo@online.de >
+ * @license GPL-2.0-or-later
+ * @author Thiemo Kreuz
  */
-interface LabelDescriptionLookup extends LabelLookup {
+interface LabelLookup {
 
 	/**
-	 * @since 2.0
-	 *
 	 * @param EntityId $entityId
 	 *
 	 * @throws LabelDescriptionLookupException
 	 * @return Term|null
 	 */
-	public function getDescription( EntityId $entityId );
+	public function getLabel( EntityId $entityId );
 
 }

--- a/tests/unit/EntityId/EntityIdLabelFormatterTest.php
+++ b/tests/unit/EntityId/EntityIdLabelFormatterTest.php
@@ -7,8 +7,8 @@ use Wikibase\DataModel\Entity\EntityId;
 use Wikibase\DataModel\Entity\ItemId;
 use Wikibase\DataModel\Entity\PropertyId;
 use Wikibase\DataModel\Services\EntityId\EntityIdLabelFormatter;
-use Wikibase\DataModel\Services\Lookup\LabelDescriptionLookup;
 use Wikibase\DataModel\Services\Lookup\LabelDescriptionLookupException;
+use Wikibase\DataModel\Services\Lookup\LabelLookup;
 use Wikibase\DataModel\Term\Term;
 
 /**
@@ -46,8 +46,7 @@ class EntityIdLabelFormatterTest extends PHPUnit_Framework_TestCase {
 	 * @param string $expectedString
 	 */
 	public function testParseWithValidArguments( EntityId $entityId, $languageCode, $expectedString ) {
-		$labelDescriptionLookup = $this->getLabelDescriptionLookup( $languageCode );
-		$formatter = new EntityIdLabelFormatter( $labelDescriptionLookup );
+		$formatter = new EntityIdLabelFormatter( $this->getLabelLookup( $languageCode ) );
 
 		$formattedValue = $formatter->formatEntityId( $entityId );
 
@@ -58,12 +57,12 @@ class EntityIdLabelFormatterTest extends PHPUnit_Framework_TestCase {
 	/**
 	 * @param string $languageCode
 	 *
-	 * @return LabelDescriptionLookup
+	 * @return LabelLookup
 	 */
-	private function getLabelDescriptionLookup( $languageCode ) {
-		$labelDescriptionLookup = $this->getMock( LabelDescriptionLookup::class );
+	private function getLabelLookup( $languageCode ) {
+		$labelLookup = $this->getMock( LabelLookup::class );
 
-		$labelDescriptionLookup->expects( $this->any() )
+		$labelLookup->expects( $this->any() )
 			->method( 'getLabel' )
 			->will( $this->returnCallback( function( EntityId $id ) use ( $languageCode ) {
 				if ( $id->getSerialization() === 'Q42' && $languageCode === 'es' ) {
@@ -73,7 +72,7 @@ class EntityIdLabelFormatterTest extends PHPUnit_Framework_TestCase {
 				}
 			} ) );
 
-		return $labelDescriptionLookup;
+		return $labelLookup;
 	}
 
 }


### PR DESCRIPTION
Discussed with the team during one of the past engineering times. @brightbyte gave the most relevant input, which says that the LabelDescriptionLookup interface combining labels and descriptions is indeed very useful, and should not be split into two separate interfaces.

Think of it this way: A description alone is not useful. You might want to render an `<a>`nchor using the label as the visible text and the description as `title="…"`.

But when you check the usages of the two `getLabel` and `getDescription` methods you realize we do have a **lot** of use-cases that use a label but **no** description. This new interface is not going to change anything, because all implementations will stay the same (for now). But it helps us cleaning up our code by using interfaces that are as narrow as possible.

[Bug: T163538](https://phabricator.wikimedia.org/T163538)