### PR TITLE
Add removed PHPCS sniffs back

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+dist: trusty
+
 env:
   - THENEEDFORTHIS=FAIL
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -2,6 +2,8 @@
 <ruleset name="WikibaseDataModelServices">
 	<rule ref="vendor/wikibase/wikibase-codesniffer/Wikibase" />
 
+	<rule ref="Generic.CodeAnalysis" />
+
 	<rule ref="Generic.Files.LineLength">
 		<properties>
 			<property name="lineLimit" value="120" />
@@ -11,6 +13,12 @@
 	<!-- Metrics are intentionally not part of the base Wikibase CodeSniffer rule set. -->
 	<rule ref="Generic.Metrics.CyclomaticComplexity" />
 	<rule ref="Generic.Metrics.NestingLevel" />
+
+	<rule ref="PSR1" />
+	<rule ref="Squiz.Arrays.ArrayBracketSpacing" />
+	<rule ref="Squiz.Strings.DoubleQuoteUsage">
+		<exclude name="Squiz.Strings.DoubleQuoteUsage.ContainsVar" />
+	</rule>
 
 	<file>.</file>
 </ruleset>


### PR DESCRIPTION
In #179 I unintentionally removed a lot of rules. I just want to go back to how it was before in this code repository, without judging if a rule makes sense or not. We might need to remove some that are to strict. We might include one or two in the wikibase-codesniffer library. This is for later to discuss.