### PR TITLE
Remove auto-generated @param-only PHPDoc blocks that add zero information

### DIFF
--- a/src/Entity/PropertyDataTypeMatcher.php
+++ b/src/Entity/PropertyDataTypeMatcher.php
@@ -21,9 +21,6 @@ class PropertyDataTypeMatcher {
 	 */
 	private $propertyDataTypeLookup;
 
-	/**
-	 * @param PropertyDataTypeLookup $propertyDataTypeLookup
-	 */
 	public function __construct( PropertyDataTypeLookup $propertyDataTypeLookup ) {
 		$this->propertyDataTypeLookup = $propertyDataTypeLookup;
 	}

--- a/src/EntityId/EntityIdLabelFormatter.php
+++ b/src/EntityId/EntityIdLabelFormatter.php
@@ -22,9 +22,6 @@ class EntityIdLabelFormatter implements EntityIdFormatter {
 	 */
 	private $labelDescriptionLookup;
 
-	/**
-	 * @param LabelDescriptionLookup $labelDescriptionLookup
-	 */
 	public function __construct( LabelDescriptionLookup $labelDescriptionLookup ) {
 		$this->labelDescriptionLookup = $labelDescriptionLookup;
 	}

--- a/src/Lookup/EntityRetrievingTermLookup.php
+++ b/src/Lookup/EntityRetrievingTermLookup.php
@@ -32,9 +32,6 @@ class EntityRetrievingTermLookup implements TermLookup {
 	 */
 	private $descriptions;
 
-	/**
-	 * @param EntityLookup $entityLookup
-	 */
 	public function __construct( EntityLookup $entityLookup ) {
 		$this->entityLookup = $entityLookup;
 	}

--- a/src/Statement/StatementGuidParser.php
+++ b/src/Statement/StatementGuidParser.php
@@ -24,9 +24,6 @@ class StatementGuidParser {
 	 */
 	private $entityIdParser;
 
-	/**
-	 * @param EntityIdParser $entityIdParser
-	 */
 	public function __construct( EntityIdParser $entityIdParser ) {
 		$this->entityIdParser = $entityIdParser;
 	}

--- a/src/Statement/StatementGuidValidator.php
+++ b/src/Statement/StatementGuidValidator.php
@@ -19,9 +19,6 @@ class StatementGuidValidator {
 	 */
 	private $entityIdParser;
 
-	/**
-	 * @param EntityIdParser $entityIdParser
-	 */
 	public function __construct( EntityIdParser $entityIdParser ) {
 		$this->entityIdParser = $entityIdParser;
 	}

--- a/tests/fixtures/FakeEntityDocument.php
+++ b/tests/fixtures/FakeEntityDocument.php
@@ -16,9 +16,6 @@ class FakeEntityDocument implements EntityDocument {
 	 */
 	private $id;
 
-	/**
-	 * @param EntityId $id
-	 */
 	public function __construct( EntityId $id ) {
 		$this->id = $id;
 	}


### PR DESCRIPTION
This patch removes auto-generated PHPDoc blocks that contain nothing but a sequence of `@param` lines that *literally* repeat what the function header below contains. These blocks add zero additional information, but clutter the code and need to be maintained. This patch does not touch PHPDoc blocks when one of the `@param` lines contains an actual comment behind the variable name, or when one of the types is not a class name.

See https://gerrit.wikimedia.org/r/360814 for the same patch in the Wikibase.git code base.