### PR TITLE
Remove non-standard Composer commands

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,18 +47,12 @@
 			"phpunit --coverage-php /dev/null"
 		],
 		"cs": [
-			"@phpcs",
-			"@phpmd"
+			"phpcs -p -s",
+			"phpmd src/,tests/unit/ text phpmd.xml"
 		],
 		"ci": [
-			"@test",
-			"@cs"
-		],
-		"phpcs": [
-			"phpcs -p -s"
-		],
-		"phpmd": [
-			"phpmd src/,tests/unit/ text phpmd.xml"
+			"@cs",
+			"@test"
 		]
 	}
 }


### PR DESCRIPTION
I'm reducing the confusing number of Composer commands to "cs", "test", and "ci". Usually, PHPCS is executed before PHPUnit. This patch also makes sure this order is consistent.