### PR TITLE
BUG: Statements are not merged when StatementList is patched

### DIFF
--- a/tests/unit/Diff/StatementListDifferPatcherTest.php
+++ b/tests/unit/Diff/StatementListDifferPatcherTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Tests\Diff;
+
+use Wikibase\DataModel\Services\Diff\StatementListDiffer;
+use Wikibase\DataModel\Services\Diff\StatementListPatcher;
+use Wikibase\DataModel\Snak\PropertyNoValueSnak;
+use Wikibase\DataModel\Snak\SnakList;
+use Wikibase\DataModel\Statement\Statement;
+use Wikibase\DataModel\Statement\StatementList;
+
+class StatementListDifferPatcherTest extends \PHPUnit_Framework_TestCase {
+
+	public function testStatemetsAreMergedWhenPatched() {
+		$guid = 'some-guid';
+		$statementLatest = new Statement(
+			new PropertyNoValueSnak( 1 ),
+			new SnakList( [ new PropertyNoValueSnak( 3 ) ] ),
+			null,
+			$guid
+		);
+		$statementFrom = new Statement(
+			new PropertyNoValueSnak( 1 ),
+			new SnakList( [ new PropertyNoValueSnak( 1 ) ] ),
+			null,
+			$guid
+		);
+		$statementTo = new Statement(
+			new PropertyNoValueSnak( 1 ),
+			new SnakList( [ new PropertyNoValueSnak( 2 ) ] ),
+			null,
+			$guid
+		);
+		$latestStatementList = new StatementList( [ $statementLatest ] );
+
+		$differ = new StatementListDiffer();
+		$patcher = new StatementListPatcher();
+
+		$diff = $differ->getDiff( new StatementList( [ $statementFrom ] ), new StatementList( [ $statementTo ] ) );
+		$patcher->patchStatementList( $latestStatementList, $diff );
+
+		$statement = $latestStatementList->getFirstStatementWithGuid( $guid );
+		$this->assertEquals( 2, $statement->getQualifiers()->count() );
+	}
+}

--- a/tests/unit/Diff/StatementListDifferPatcherTest.php
+++ b/tests/unit/Diff/StatementListDifferPatcherTest.php
@@ -40,6 +40,8 @@ class StatementListDifferPatcherTest extends \PHPUnit_Framework_TestCase {
 		$patcher->patchStatementList( $latestStatementList, $diff );
 
 		$statement = $latestStatementList->getFirstStatementWithGuid( $guid );
+		$this->assertEquals( new PropertyNoValueSnak( 3 ), $statement->getQualifiers()[0] );
+		$this->assertEquals( new PropertyNoValueSnak( 2 ), $statement->getQualifiers()[1] );
 		$this->assertEquals( 2, $statement->getQualifiers()->count() );
 	}
 }


### PR DESCRIPTION
While I was trying to figure out how I should patch Lexeme Forms I tried to understand how the things are for statements and that is what I discovered:
Individual statements are never patched. Each statement just gets replaced with the new one. As I see it it is a problem, taking into account the possibility to "edit old revisions" (I mean that client sends `baseRevId`) it might be quiet harmful if you edit qualifiers or references, because those might be silently removed from the latest revision.
