### PR TITLE
Add ReferencedEntityIdLookup interface

### DIFF
--- a/src/Lookup/ReferencedEntityIdLookup.php
+++ b/src/Lookup/ReferencedEntityIdLookup.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Lookup;
+
+use Wikibase\DataModel\Entity\EntityId;
+use Wikibase\DataModel\Entity\PropertyId;
+
+/**
+ * Service interface for getting a referenced entity (out of a specified set),
+ * from a given starting entity. The starting entity, and the target entities
+ * are (potentially indirectly, via intermediate entities) linked by statements
+ * with a given property ID, pointing from the starting entity to one of the
+ * target entities.
+ *
+ * @since 3.10
+ *
+ * @license GPL-2.0-or-later
+ * @author Marius Hoch
+ */
+interface ReferencedEntityIdLookup {
+
+	/**
+	 * Get the referenced entity (out of $toIds), from a given entity. The starting entity, and
+	 * the target entities are (potentially indirectly, via intermediate entities) linked by
+	 * statements with the given property ID, pointing from the starting entity to one of the
+	 * target entities.
+	 * Implementations of this may or may not return the closest referenced entity (where
+	 * distance is defined by the number of intermediate entities).
+	 *
+	 * @since 3.10
+	 *
+	 * @param EntityId $fromId
+	 * @param PropertyId $propertyId
+	 * @param EntityId[] $toIds
+	 *
+	 * @return EntityId|null Returns null in case none of the target entities are referenced.
+	 * @throws ReferencedEntityIdLookupException
+	 */
+	public function getReferencedEntityId( EntityId $fromId, PropertyId $propertyId, array $toIds );
+
+}

--- a/src/Lookup/ReferencedEntityIdLookupException.php
+++ b/src/Lookup/ReferencedEntityIdLookupException.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Lookup;
+
+use Exception;
+use RuntimeException;
+use Wikibase\DataModel\Entity\EntityId;
+use Wikibase\DataModel\Entity\PropertyId;
+
+/**
+ * @since 3.10
+ *
+ * @license GPL-2.0-or-later
+ * @author Marius Hoch
+ */
+class ReferencedEntityIdLookupException extends RuntimeException {
+
+	/**
+	 * @var EntityId
+	 */
+	private $fromId;
+
+	/**
+	 * @var PropertyId
+	 */
+	private $propertyId;
+
+	/**
+	 * @var EntityId[]
+	 */
+	private $toIds;
+
+	/**
+	 * @param EntityId $fromId
+	 * @param PropertyId $propertyId
+	 * @param EntityId[] $toIds
+	 * @param string|null $message
+	 * @param Exception|null $previous
+	 */
+	public function __construct(
+		EntityId $fromId,
+		PropertyId $propertyId,
+		array $toIds,
+		$message = null,
+		Exception $previous = null
+	) {
+		$this->fromId = $fromId;
+		$this->propertyId = $propertyId;
+		$this->toIds = $toIds;
+
+		$targets = array_map(
+			function ( EntityId $entityId ) {
+				return $entityId->getSerialization();
+			},
+			$toIds
+		);
+		$targets = implode( ', ', $targets );
+
+		$message = $message ?: 'Referenced entity id lookup failed. Tried to find a referenced entity out of ' .
+			$targets . ' linked from ' . $fromId->getSerialization() . ' via ' . $propertyId->getSerialization();
+
+		parent::__construct( $message, 0, $previous );
+	}
+
+}

--- a/tests/unit/Lookup/ReferencedEntityIdLookupExceptionTest.php
+++ b/tests/unit/Lookup/ReferencedEntityIdLookupExceptionTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Tests\Lookup;
+
+use Exception;
+use PHPUnit_Framework_TestCase;
+use Wikibase\DataModel\Entity\ItemId;
+use Wikibase\DataModel\Entity\PropertyId;
+use Wikibase\DataModel\Services\Lookup\ReferencedEntityIdLookupException;
+
+/**
+ * @covers Wikibase\DataModel\Services\Lookup\ReferencedEntityIdLookupException
+ *
+ * @license GPL-2.0-or-later
+ * @author Marius Hoch
+ */
+class ReferencedEntityIdLookupExceptionTest extends PHPUnit_Framework_TestCase {
+
+	public function testConstructorWithOnlyRequiredArguments() {
+		$entityId = new ItemId( 'Q1' );
+		$propertyId = new PropertyId( 'P12' );
+		$toIds = [
+			new ItemId( 'Q5' ),
+			new ItemId( 'Q2013' )
+		];
+		$exception = new ReferencedEntityIdLookupException( $entityId, $propertyId, $toIds );
+
+		$this->assertSame(
+			'Referenced entity id lookup failed. ' .
+			'Tried to find a referenced entity out of Q5, Q2013 linked from Q1 via P12',
+			$exception->getMessage()
+		);
+		$this->assertSame( 0, $exception->getCode() );
+		$this->assertNull( $exception->getPrevious() );
+	}
+
+	public function testConstructorWithAllArguments() {
+		$entityId = new ItemId( 'Q1' );
+		$propertyId = new PropertyId( 'P12' );
+		$toIds = [
+			new ItemId( 'Q5' ),
+			new ItemId( 'Q2013' )
+		];
+		$previous = new Exception( 'previous' );
+
+		$exception = new ReferencedEntityIdLookupException(
+			$entityId,
+			$propertyId,
+			$toIds,
+			'blah blah',
+			$previous
+		);
+
+		$this->assertSame( 'blah blah', $exception->getMessage() );
+		$this->assertSame( 0, $exception->getCode() );
+		$this->assertSame( $previous, $exception->getPrevious() );
+	}
+
+}


### PR DESCRIPTION
I chose a more general name here, as this can be used to lookup several kinds of relations (not only "parent" relations).

This is supposed to have an implementation similar to `TypeCheckerHelper::isSubclassOf` (in WikibaseQualityConstraints).

Needed in the context of [T179155](https://phabricator.wikimedia.org/T179155), but can probably also be re-used in WikibaseQualityConstraints.