### PR TITLE
 Add compatibility with DataModel 8.x 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ matrix:
     - env: DM=~6.3
       php: hhvm
     - env: DM=~7.5
+      php: 5.6
+    - env: DM=~7.5
       php: 7
     - env: DM=~8.0
       php: 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,16 @@
 language: php
 
-dist: trusty
-
-env:
-  - THENEEDFORTHIS=FAIL
-
 matrix:
   fast_finish: true
   include:
-    - env: DM=@dev
-      php: 5.5
-    - env: DM=~6.3
-      php: 5.5
-    - env: DM=~6.3
-      php: 5.6
-    - env: DM=~6.3
-      php: 7
     - env: DM=~6.3
       php: hhvm
-  exclude:
-    - env: THENEEDFORTHIS=FAIL
+    - env: DM=~7.5
+      php: 7
+    - env: DM=~8.0
+      php: 7.1
+    - env: DM=@dev
+      php: 7.2
   allow_failures:
     - env: DM=@dev
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -4,6 +4,7 @@
 
 * Added compatibility with Wikibase DataModel 8.x
 * Added compatibility with DataValues 2.x
+* Raised minimum PHP version to 5.6
 
 ## Version 3.10.0 (2018-05-31)
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,10 @@
 # Wikibase DataModel Services release notes
 
+## Version 3.11.0 (2018-08-07)
+
+* Added compatibility with Wikibase DataModel 8.x
+* Added compatibility with DataValues 2.x
+
 ## Version 3.10.0 (2018-05-31)
 
 * Added `ReferencedEntityIdLookup` interface, along with:

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
 	},
 	"require": {
 		"php": ">=5.5.9",
-		"wikibase/data-model": "~7.0|~6.3",
-		"data-values/data-values": "~0.1|~1.0",
+		"wikibase/data-model": "~8.0|~7.0|~6.3",
+		"data-values/data-values": "~2.0|~1.0",
 		"diff/diff": "~2.3|~1.0",
 		"wikimedia/assert": "~0.2.2"
 	},
@@ -38,7 +38,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "3.10.x-dev"
+			"dev-master": "3.11.x-dev"
 		}
 	},
 	"scripts": {

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
 	},
 	"require-dev": {
 		"phpmd/phpmd": "~2.3",
-		"phpunit/phpunit": "~4.8",
+		"phpunit/phpunit": "~5.7",
 		"wikibase/wikibase-codesniffer": "^0.3.0"
 	},
 	"autoload": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 		"irc": "irc://irc.freenode.net/wikidata"
 	},
 	"require": {
-		"php": ">=5.5.9",
+		"php": ">=5.6.0",
 		"wikibase/data-model": "~8.0|~7.0|~6.3",
 		"data-values/data-values": "~2.0|~1.0",
 		"diff/diff": "~2.3|~1.0",

--- a/tests/fixtures/EntityOfUnknownType.php
+++ b/tests/fixtures/EntityOfUnknownType.php
@@ -40,8 +40,6 @@ class EntityOfUnknownType implements EntityDocument {
 	/**
 	 * @see EntityDocument::equals
 	 *
-	 * @since 3.3
-	 *
 	 * @param mixed $target
 	 *
 	 * @return bool Always true.
@@ -53,12 +51,16 @@ class EntityOfUnknownType implements EntityDocument {
 	/**
 	 * @see EntityDocument::copy
 	 *
-	 * @since 3.3
-	 *
 	 * @return self
 	 */
 	public function copy() {
 		return $this;
+	}
+
+	/**
+	 * @see EntityDocument::clear
+	 */
+	public function clear() {
 	}
 
 }

--- a/tests/fixtures/FakeEntityDocument.php
+++ b/tests/fixtures/FakeEntityDocument.php
@@ -51,8 +51,6 @@ class FakeEntityDocument implements EntityDocument {
 	/**
 	 * @see EntityDocument::equals
 	 *
-	 * @since 3.3
-	 *
 	 * @param mixed $target
 	 *
 	 * @return bool Always true.
@@ -64,12 +62,16 @@ class FakeEntityDocument implements EntityDocument {
 	/**
 	 * @see EntityDocument::copy
 	 *
-	 * @since 3.3
-	 *
 	 * @return self
 	 */
 	public function copy() {
 		return new self( $this->id );
+	}
+
+	/**
+	 * @see EntityDocument::clear
+	 */
+	public function clear() {
 	}
 
 }

--- a/tests/unit/ByPropertyIdGrouperTest.php
+++ b/tests/unit/ByPropertyIdGrouperTest.php
@@ -179,7 +179,7 @@ class ByPropertyIdGrouperTest extends PHPUnit_Framework_TestCase {
 	 * @return PropertyIdProvider
 	 */
 	private function getPropertyIdProviderMock( $propertyId, $type = null ) {
-		$propertyIdProvider = $this->getMock( Snak::class );
+		$propertyIdProvider = $this->createMock( Snak::class );
 
 		$propertyIdProvider->expects( $this->once() )
 			->method( 'getPropertyId' )

--- a/tests/unit/EntityId/EntityIdLabelFormatterTest.php
+++ b/tests/unit/EntityId/EntityIdLabelFormatterTest.php
@@ -60,7 +60,7 @@ class EntityIdLabelFormatterTest extends PHPUnit_Framework_TestCase {
 	 * @return LabelLookup
 	 */
 	private function getLabelLookup( $languageCode ) {
-		$labelLookup = $this->getMock( LabelLookup::class );
+		$labelLookup = $this->createMock( LabelLookup::class );
 
 		$labelLookup->expects( $this->any() )
 			->method( 'getLabel' )

--- a/tests/unit/EntityId/EscapingEntityIdFormatterTest.php
+++ b/tests/unit/EntityId/EscapingEntityIdFormatterTest.php
@@ -16,7 +16,7 @@ use Wikibase\DataModel\Services\EntityId\EscapingEntityIdFormatter;
 class EscapingEntityIdFormatterTest extends PHPUnit_Framework_TestCase {
 
 	public function testFormat() {
-		$entityIdFormatter = $this->getMock( EntityIdFormatter::class );
+		$entityIdFormatter = $this->createMock( EntityIdFormatter::class );
 		$entityIdFormatter->expects( $this->once() )
 			->method( 'formatEntityId' )
 			->will( $this->returnValue( 'Q1 is &%$;§ > Q2' ) );

--- a/tests/unit/EntityId/PrefixMappingEntityIdParserTest.php
+++ b/tests/unit/EntityId/PrefixMappingEntityIdParserTest.php
@@ -74,7 +74,7 @@ class PrefixMappingEntityIdParserTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testEntityIdParsingExceptionsAreNotCaught() {
-		$regularParser = $this->getMock( EntityIdParser::class );
+		$regularParser = $this->createMock( EntityIdParser::class );
 		$regularParser->expects( $this->any() )
 			->method( 'parse' )
 			->will( $this->throwException( new EntityIdParsingException() ) );

--- a/tests/unit/Lookup/DisabledEntityTypesEntityLookupTest.php
+++ b/tests/unit/Lookup/DisabledEntityTypesEntityLookupTest.php
@@ -20,7 +20,7 @@ class DisabledEntityTypesEntityLookupTest extends \PHPUnit_Framework_TestCase {
 	 * @return EntityLookup
 	 */
 	private function getEntityLookup() {
-		$entityLookup = $this->getMock( EntityLookup::class );
+		$entityLookup = $this->createMock( EntityLookup::class );
 
 		$entityLookup->expects( $this->any() )
 			->method( 'hasEntity' )

--- a/tests/unit/Lookup/DispatchingEntityLookupTest.php
+++ b/tests/unit/Lookup/DispatchingEntityLookupTest.php
@@ -81,7 +81,7 @@ class DispatchingEntityLookupTest extends \PHPUnit_Framework_TestCase {
 	 * @return EntityLookup
 	 */
 	private function getExceptionThrowingLookup( Exception $exception ) {
-		$lookup = $this->getMock( EntityLookup::class );
+		$lookup = $this->createMock( EntityLookup::class );
 		$lookup->expects( $this->any() )
 			->method( $this->anything() )
 			->will( $this->throwException( $exception ) );
@@ -120,7 +120,7 @@ class DispatchingEntityLookupTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testGivenEntityIdFromUnknownRepository_hasEntityReturnsFalse() {
-		$dispatchingLookup = new DispatchingEntityLookup( [ '' => $this->getMock( EntityLookup::class ), ] );
+		$dispatchingLookup = new DispatchingEntityLookup( [ '' => $this->createMock( EntityLookup::class ), ] );
 
 		$this->assertFalse( $dispatchingLookup->hasEntity( new ItemId( 'foo:Q1' ) ) );
 	}

--- a/tests/unit/Lookup/EntityRetrievingClosestReferencedEntityIdLookupTest.php
+++ b/tests/unit/Lookup/EntityRetrievingClosestReferencedEntityIdLookupTest.php
@@ -38,7 +38,7 @@ class EntityRetrievingClosestReferencedEntityIdLookupTest extends PHPUnit_Framew
 	 * @return EntityLookup
 	 */
 	private function restrictEntityLookup( EntityLookup $entityLookup, $expectedNumberOfGetEntityCalls = null ) {
-		$entityLookupMock = $this->getMock( EntityLookup::class );
+		$entityLookupMock = $this->createMock( EntityLookup::class );
 
 		$entityLookupMock->expects(
 			$expectedNumberOfGetEntityCalls === null ? $this->any() : $this->exactly( $expectedNumberOfGetEntityCalls )
@@ -56,7 +56,7 @@ class EntityRetrievingClosestReferencedEntityIdLookupTest extends PHPUnit_Framew
 	 * @return EntityPrefetcher
 	 */
 	private function newEntityPrefetcher( $expectedPrefetches ) {
-		$entityPrefetcher = $this->getMock( EntityPrefetcher::class );
+		$entityPrefetcher = $this->createMock( EntityPrefetcher::class );
 		$entityPrefetcher->expects( $this->exactly( $expectedPrefetches ) )
 			->method( 'prefetch' )
 			->with( $this->isType( 'array' ) );

--- a/tests/unit/Lookup/InProcessCachingDataTypeLookupTest.php
+++ b/tests/unit/Lookup/InProcessCachingDataTypeLookupTest.php
@@ -16,7 +16,7 @@ use Wikibase\DataModel\Services\Lookup\PropertyDataTypeLookup;
 class InProcessCachingDataTypeLookupTest extends PHPUnit_Framework_TestCase {
 
 	public function testWhenCacheIsEmpty_decoratedLookupValueIsReturned() {
-		$decoratedLookup = $this->getMock( PropertyDataTypeLookup::class );
+		$decoratedLookup = $this->createMock( PropertyDataTypeLookup::class );
 
 		$decoratedLookup->expects( $this->once() )
 			->method( 'getDataTypeIdForProperty' )
@@ -32,7 +32,7 @@ class InProcessCachingDataTypeLookupTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testWhenValueInCache_cacheValueIsReturned() {
-		$decoratedLookup = $this->getMock( PropertyDataTypeLookup::class );
+		$decoratedLookup = $this->createMock( PropertyDataTypeLookup::class );
 
 		$decoratedLookup->expects( $this->once() )
 			->method( 'getDataTypeIdForProperty' )

--- a/tests/unit/Lookup/LanguageLabelDescriptionLookupTest.php
+++ b/tests/unit/Lookup/LanguageLabelDescriptionLookupTest.php
@@ -16,7 +16,7 @@ use Wikibase\DataModel\Term\Term;
 class LanguageLabelDescriptionLookupTest extends \PHPUnit_Framework_TestCase {
 
 	public function testGetLabelCallsTermLookupAndReturnsStringAsTerm() {
-		$termLookup = $this->getMock( TermLookup::class );
+		$termLookup = $this->createMock( TermLookup::class );
 
 		$termLookup->expects( $this->once() )
 			->method( 'getLabel' )
@@ -32,7 +32,7 @@ class LanguageLabelDescriptionLookupTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testGetDescriptionCallsTermLookupAndReturnsStringAsTerm() {
-		$termLookup = $this->getMock( TermLookup::class );
+		$termLookup = $this->createMock( TermLookup::class );
 
 		$termLookup->expects( $this->once() )
 			->method( 'getDescription' )
@@ -48,7 +48,7 @@ class LanguageLabelDescriptionLookupTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testWhenGettingNull_getLabelReturnsNull() {
-		$termLookup = $this->getMock( TermLookup::class );
+		$termLookup = $this->createMock( TermLookup::class );
 
 		$termLookup->expects( $this->once() )
 			->method( 'getLabel' )
@@ -60,7 +60,7 @@ class LanguageLabelDescriptionLookupTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testWhenGettingNull_getDescriptionReturnsNull() {
-		$termLookup = $this->getMock( TermLookup::class );
+		$termLookup = $this->createMock( TermLookup::class );
 
 		$termLookup->expects( $this->once() )
 			->method( 'getDescription' )

--- a/tests/unit/Lookup/RedirectResolvingEntityLookupTest.php
+++ b/tests/unit/Lookup/RedirectResolvingEntityLookupTest.php
@@ -42,7 +42,7 @@ class RedirectResolvingEntityLookupTest extends \PHPUnit_Framework_TestCase {
 	 * @return EntityLookup
 	 */
 	public function getLookupDouble() {
-		$mock = $this->getMock( EntityLookup::class );
+		$mock = $this->createMock( EntityLookup::class );
 
 		$mock->expects( $this->any() )
 			->method( 'getEntity' )

--- a/tests/unit/Lookup/RestrictedEntityLookupTest.php
+++ b/tests/unit/Lookup/RestrictedEntityLookupTest.php
@@ -20,7 +20,7 @@ class RestrictedEntityLookupTest extends \PHPUnit_Framework_TestCase {
 	 * @return EntityLookup
 	 */
 	private function getEntityLookup() {
-		$entityLookup = $this->getMock( EntityLookup::class );
+		$entityLookup = $this->createMock( EntityLookup::class );
 
 		$entityLookup->expects( $this->any() )
 			->method( 'hasEntity' )

--- a/tests/unit/Statement/Filter/DataTypeStatementFilterTest.php
+++ b/tests/unit/Statement/Filter/DataTypeStatementFilterTest.php
@@ -22,7 +22,7 @@ class DataTypeStatementFilterTest extends PHPUnit_Framework_TestCase {
 	 * @return PropertyDataTypeLookup
 	 */
 	private function getDataTypeLookup() {
-		$dataTypeLookup = $this->getMock( PropertyDataTypeLookup::class );
+		$dataTypeLookup = $this->createMock( PropertyDataTypeLookup::class );
 
 		$dataTypeLookup->expects( $this->once() )
 			->method( 'getDataTypeIdForProperty' )

--- a/tests/unit/Statement/Grouper/FilteringStatementGrouperTest.php
+++ b/tests/unit/Statement/Grouper/FilteringStatementGrouperTest.php
@@ -24,7 +24,7 @@ class FilteringStatementGrouperTest extends PHPUnit_Framework_TestCase {
 	 * @return StatementFilter
 	 */
 	private function newStatementFilter( $propertyId = 'P1' ) {
-		$filter = $this->getMock( StatementFilter::class );
+		$filter = $this->createMock( StatementFilter::class );
 
 		$filter->expects( $this->any() )
 			->method( 'statementMatches' )


### PR DESCRIPTION
Includes running the CI with more versions of DM and PHP and an upgrade of PHPUnit to the maximum version supported by WMF infrastructure (which is only unsupported for half a year now and does not fail as hard with PHP 7.2)