### PR TITLE
UnresolvedEntityRedirectException: Mention source entity id

### DIFF
--- a/src/Lookup/UnresolvedEntityRedirectException.php
+++ b/src/Lookup/UnresolvedEntityRedirectException.php
@@ -33,9 +33,12 @@ class UnresolvedEntityRedirectException extends EntityLookupException {
 		$message = null,
 		Exception $previous = null
 	) {
+		$defaultMessage = 'Unresolved redirect from ' . $entityId->getSerialization() . ' to '
+			. $redirectTargetId->getSerialization();
+
 		parent::__construct(
 			$entityId,
-			$message !== null ? $message : 'Unresolved redirect to ' . $redirectTargetId->getSerialization(),
+			$message ?: $defaultMessage,
 			$previous
 		);
 

--- a/tests/unit/Lookup/UnresolvedEntityRedirectExceptionTest.php
+++ b/tests/unit/Lookup/UnresolvedEntityRedirectExceptionTest.php
@@ -22,7 +22,7 @@ class UnresolvedEntityRedirectExceptionTest extends PHPUnit_Framework_TestCase {
 
 		$this->assertSame( $entityId, $exception->getEntityId() );
 		$this->assertSame( $redirectTargetId, $exception->getRedirectTargetId() );
-		$this->assertSame( 'Unresolved redirect to Q2', $exception->getMessage() );
+		$this->assertSame( 'Unresolved redirect from Q1 to Q2', $exception->getMessage() );
 		$this->assertSame( 0, $exception->getCode() );
 		$this->assertNull( $exception->getPrevious() );
 	}


### PR DESCRIPTION
In some cases it might not immediately be obvious where the `UnresolvedEntityRedirectException` came from.

Related: https://phabricator.wikimedia.org/T93273