### PR TITLE
Update Wikibase PHPCS rule set to latest release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
 	"require-dev": {
 		"phpmd/phpmd": "~2.3",
 		"phpunit/phpunit": "~5.7",
-		"wikibase/wikibase-codesniffer": "^0.3.0"
+		"wikibase/wikibase-codesniffer": "^0.5.0"
 	},
 	"autoload": {
 		"psr-4": {

--- a/src/ByPropertyIdGrouper.php
+++ b/src/ByPropertyIdGrouper.php
@@ -13,7 +13,7 @@ use Wikibase\DataModel\PropertyIdProvider;
  *
  * @since 1.0
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Bene* < benestar.wikimedia@gmail.com >
  */
 class ByPropertyIdGrouper {

--- a/src/DataValue/ValuesFinder.php
+++ b/src/DataValue/ValuesFinder.php
@@ -14,7 +14,7 @@ use Wikibase\DataModel\Snak\Snak;
  *
  * @since 1.1
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Bene* < benestar.wikimedia@gmail.com >
  */
 class ValuesFinder {

--- a/src/Diff/EntityDiff.php
+++ b/src/Diff/EntityDiff.php
@@ -11,7 +11,7 @@ use Wikibase\DataModel\Entity\Item;
  *
  * @since 1.0
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class EntityDiff extends Diff {

--- a/src/Diff/EntityDiffer.php
+++ b/src/Diff/EntityDiffer.php
@@ -9,7 +9,7 @@ use Wikibase\DataModel\Entity\EntityDocument;
 /**
  * @since 1.0
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class EntityDiffer {

--- a/src/Diff/EntityDifferStrategy.php
+++ b/src/Diff/EntityDifferStrategy.php
@@ -8,7 +8,7 @@ use Wikibase\DataModel\Entity\EntityDocument;
 /**
  * @since 1.0
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 interface EntityDifferStrategy {

--- a/src/Diff/EntityPatcher.php
+++ b/src/Diff/EntityPatcher.php
@@ -9,7 +9,7 @@ use Wikibase\DataModel\Entity\EntityDocument;
 /**
  * @since 1.0
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Christoph Fischer < christoph.fischer@wikimedia.de >
  */

--- a/src/Diff/EntityPatcherStrategy.php
+++ b/src/Diff/EntityPatcherStrategy.php
@@ -8,7 +8,7 @@ use Wikibase\DataModel\Entity\EntityDocument;
 /**
  * @since 1.0
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 interface EntityPatcherStrategy {

--- a/src/Diff/EntityTypeAwareDiffOpFactory.php
+++ b/src/Diff/EntityTypeAwareDiffOpFactory.php
@@ -11,7 +11,7 @@ use InvalidArgumentException;
  *
  * @since 1.2
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Daniel Kinzler
  */
 class EntityTypeAwareDiffOpFactory extends DiffOpFactory {

--- a/src/Diff/Internal/AliasGroupListPatcher.php
+++ b/src/Diff/Internal/AliasGroupListPatcher.php
@@ -15,7 +15,7 @@ use Wikibase\DataModel\Term\AliasGroupList;
  *
  * @since 3.6
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Thiemo Kreuz
  */

--- a/src/Diff/Internal/FingerprintPatcher.php
+++ b/src/Diff/Internal/FingerprintPatcher.php
@@ -12,7 +12,7 @@ use Wikibase\DataModel\Term\Fingerprint;
  *
  * @since 1.0
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Thiemo Kreuz
  */

--- a/src/Diff/Internal/SiteLinkListPatcher.php
+++ b/src/Diff/Internal/SiteLinkListPatcher.php
@@ -12,7 +12,7 @@ use Wikibase\DataModel\SiteLinkList;
 /**
  * Package private.
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Thiemo Kreuz
  */

--- a/src/Diff/ItemDiff.php
+++ b/src/Diff/ItemDiff.php
@@ -10,7 +10,7 @@ use Diff\DiffOp\DiffOp;
  *
  * @since 1.0
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class ItemDiff extends EntityDiff {

--- a/src/Diff/ItemDiffer.php
+++ b/src/Diff/ItemDiffer.php
@@ -12,7 +12,7 @@ use Wikibase\DataModel\SiteLinkList;
 /**
  * @since 1.0
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class ItemDiffer implements EntityDifferStrategy {

--- a/src/Diff/ItemPatcher.php
+++ b/src/Diff/ItemPatcher.php
@@ -11,7 +11,7 @@ use Wikibase\DataModel\Services\Diff\Internal\SiteLinkListPatcher;
 /**
  * @since 1.0
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class ItemPatcher implements EntityPatcherStrategy {

--- a/src/Diff/PropertyDiffer.php
+++ b/src/Diff/PropertyDiffer.php
@@ -12,7 +12,7 @@ use Wikibase\DataModel\Statement\StatementList;
 /**
  * @since 1.0
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class PropertyDiffer implements EntityDifferStrategy {

--- a/src/Diff/PropertyPatcher.php
+++ b/src/Diff/PropertyPatcher.php
@@ -10,7 +10,7 @@ use Wikibase\DataModel\Services\Diff\Internal\FingerprintPatcher;
 /**
  * @since 1.0
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class PropertyPatcher implements EntityPatcherStrategy {

--- a/src/Diff/StatementListDiffer.php
+++ b/src/Diff/StatementListDiffer.php
@@ -11,7 +11,7 @@ use Wikibase\DataModel\Statement\StatementList;
 /**
  * @since 3.6
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class StatementListDiffer {

--- a/src/Diff/StatementListPatcher.php
+++ b/src/Diff/StatementListPatcher.php
@@ -13,7 +13,7 @@ use Wikibase\DataModel\Statement\StatementList;
 /**
  * @since 3.6
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Thiemo Kreuz
  */

--- a/src/Diff/TermListPatcher.php
+++ b/src/Diff/TermListPatcher.php
@@ -13,7 +13,7 @@ use Wikibase\DataModel\Term\TermList;
 /**
  * @since 3.6
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Thiemo Kreuz
  */

--- a/src/Entity/EntityPrefetcher.php
+++ b/src/Entity/EntityPrefetcher.php
@@ -10,7 +10,7 @@ use Wikibase\DataModel\Entity\EntityId;
  *
  * @since 1.1
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Marius Hoch < hoo@online.de >
  */
 interface EntityPrefetcher {

--- a/src/Entity/NullEntityPrefetcher.php
+++ b/src/Entity/NullEntityPrefetcher.php
@@ -9,7 +9,7 @@ use Wikibase\DataModel\Entity\EntityId;
  *
  * @since 1.1
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Marius Hoch < hoo@online.de >
  *
  * @codeCoverageIgnore

--- a/src/Entity/PropertyDataTypeMatcher.php
+++ b/src/Entity/PropertyDataTypeMatcher.php
@@ -11,7 +11,7 @@ use Wikibase\DataModel\Services\Lookup\PropertyDataTypeLookupException;
  *
  * @since 3.1
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Katie Filbert < aude.wiki@gmail.com >
  */
 class PropertyDataTypeMatcher {

--- a/src/EntityId/EntityIdComposer.php
+++ b/src/EntityId/EntityIdComposer.php
@@ -16,7 +16,7 @@ use Wikibase\DataModel\Entity\EntityId;
  *
  * @since 3.9
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Thiemo Kreuz
  */
 class EntityIdComposer {

--- a/src/EntityId/EntityIdFormatter.php
+++ b/src/EntityId/EntityIdFormatter.php
@@ -7,7 +7,7 @@ use Wikibase\DataModel\Entity\EntityId;
 /**
  * @since 1.1
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Thiemo Kreuz
  */

--- a/src/EntityId/EntityIdLabelFormatter.php
+++ b/src/EntityId/EntityIdLabelFormatter.php
@@ -10,7 +10,7 @@ use Wikibase\DataModel\Term\Term;
 /**
  * @since 1.1
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Katie Filbert < aude.wiki@gmail.com >
  * @author Daniel Kinzler

--- a/src/EntityId/EntityIdPager.php
+++ b/src/EntityId/EntityIdPager.php
@@ -9,7 +9,7 @@ use Wikibase\DataModel\Entity\EntityId;
  *
  * @since 3.7
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Daniel Kinzler
  */
 interface EntityIdPager {

--- a/src/EntityId/EscapingEntityIdFormatter.php
+++ b/src/EntityId/EscapingEntityIdFormatter.php
@@ -11,7 +11,7 @@ use Wikibase\DataModel\Entity\EntityId;
  *
  * @since 1.1
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Daniel Kinzler
  */
 class EscapingEntityIdFormatter implements EntityIdFormatter {

--- a/src/EntityId/PlainEntityIdFormatter.php
+++ b/src/EntityId/PlainEntityIdFormatter.php
@@ -7,7 +7,7 @@ use Wikibase\DataModel\Entity\EntityId;
 /**
  * @since 1.1
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Thiemo Kreuz
  */

--- a/src/EntityId/PrefixMappingEntityIdParser.php
+++ b/src/EntityId/PrefixMappingEntityIdParser.php
@@ -19,7 +19,7 @@ use Wikibase\DataModel\Entity\EntityIdParsingException;
  *
  * @since 3.7
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  */
 class PrefixMappingEntityIdParser implements EntityIdParser {
 

--- a/src/EntityId/PrefixMappingEntityIdParserFactory.php
+++ b/src/EntityId/PrefixMappingEntityIdParserFactory.php
@@ -9,7 +9,7 @@ use Wikimedia\Assert\ParameterAssertionException;
 /**
  * @since 3.7
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  */
 class PrefixMappingEntityIdParserFactory {
 

--- a/src/EntityId/SuffixEntityIdParser.php
+++ b/src/EntityId/SuffixEntityIdParser.php
@@ -12,7 +12,7 @@ use Wikibase\DataModel\Entity\EntityIdParsingException;
  *
  * @since 1.1
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Daniel Kinzler
  */
 class SuffixEntityIdParser implements EntityIdParser {

--- a/src/Lookup/DisabledEntityTypesEntityLookup.php
+++ b/src/Lookup/DisabledEntityTypesEntityLookup.php
@@ -12,7 +12,7 @@ use Wikimedia\Assert\Assert;
  *
  * @since 3.9
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Amir Sarabadani
  */
 class DisabledEntityTypesEntityLookup implements EntityLookup {

--- a/src/Lookup/DispatchingEntityLookup.php
+++ b/src/Lookup/DispatchingEntityLookup.php
@@ -16,7 +16,7 @@ use Wikimedia\Assert\ParameterAssertionException;
  *
  * @since 3.7
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  */
 class DispatchingEntityLookup implements EntityLookup {
 

--- a/src/Lookup/EntityAccessLimitException.php
+++ b/src/Lookup/EntityAccessLimitException.php
@@ -5,7 +5,7 @@ namespace Wikibase\DataModel\Services\Lookup;
 /**
  * @since 2.1
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Marius Hoch < hoo@online.de >
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */

--- a/src/Lookup/EntityLookup.php
+++ b/src/Lookup/EntityLookup.php
@@ -10,7 +10,7 @@ use Wikibase\DataModel\Entity\EntityId;
  *
  * @since 1.1
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Daniel Kinzler
  */

--- a/src/Lookup/EntityLookupException.php
+++ b/src/Lookup/EntityLookupException.php
@@ -9,7 +9,7 @@ use Wikibase\DataModel\Entity\EntityId;
 /**
  * @since 2.0
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Addshore
  */
 class EntityLookupException extends RuntimeException {

--- a/src/Lookup/EntityRedirectLookup.php
+++ b/src/Lookup/EntityRedirectLookup.php
@@ -9,7 +9,7 @@ use Wikibase\DataModel\Entity\EntityId;
  *
  * @since 1.1
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Daniel Kinzler
  */
 interface EntityRedirectLookup {

--- a/src/Lookup/EntityRedirectLookupException.php
+++ b/src/Lookup/EntityRedirectLookupException.php
@@ -9,7 +9,7 @@ use Wikibase\DataModel\Entity\EntityId;
 /**
  * @since 2.0
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Addshore
  */
 class EntityRedirectLookupException extends RuntimeException {

--- a/src/Lookup/EntityRetrievingDataTypeLookup.php
+++ b/src/Lookup/EntityRetrievingDataTypeLookup.php
@@ -11,7 +11,7 @@ use Wikibase\DataModel\Entity\PropertyId;
  *
  * @since 1.1
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class EntityRetrievingDataTypeLookup implements PropertyDataTypeLookup {

--- a/src/Lookup/EntityRetrievingTermLookup.php
+++ b/src/Lookup/EntityRetrievingTermLookup.php
@@ -11,7 +11,7 @@ use Wikibase\DataModel\Term\TermList;
 /**
  * @since 1.1
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Katie Filbert < aude.wiki@gmail.com >
  * @author Addshore
  */

--- a/src/Lookup/InMemoryDataTypeLookup.php
+++ b/src/Lookup/InMemoryDataTypeLookup.php
@@ -12,7 +12,7 @@ use Wikibase\DataModel\Entity\PropertyId;
  *
  * @since 1.0
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class InMemoryDataTypeLookup implements PropertyDataTypeLookup {

--- a/src/Lookup/InMemoryEntityLookup.php
+++ b/src/Lookup/InMemoryEntityLookup.php
@@ -15,7 +15,7 @@ use Wikibase\DataModel\Entity\EntityId;
  *
  * @since 2.0
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class InMemoryEntityLookup implements EntityLookup {

--- a/src/Lookup/InProcessCachingDataTypeLookup.php
+++ b/src/Lookup/InProcessCachingDataTypeLookup.php
@@ -9,7 +9,7 @@ use Wikibase\DataModel\Entity\PropertyId;
  *
  * @since 3.1
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Katie Filbert < aude.wiki@gmail.com >
  */
 class InProcessCachingDataTypeLookup implements PropertyDataTypeLookup {

--- a/src/Lookup/ItemLookup.php
+++ b/src/Lookup/ItemLookup.php
@@ -8,7 +8,7 @@ use Wikibase\DataModel\Entity\ItemId;
 /**
  * @since 1.0
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Thomas Pellissier Tanon
  */
 interface ItemLookup {

--- a/src/Lookup/ItemLookupException.php
+++ b/src/Lookup/ItemLookupException.php
@@ -8,7 +8,7 @@ use Wikibase\DataModel\Entity\ItemId;
 /**
  * @since 2.0
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Addshore
  */
 class ItemLookupException extends EntityLookupException {

--- a/src/Lookup/LabelDescriptionLookup.php
+++ b/src/Lookup/LabelDescriptionLookup.php
@@ -8,7 +8,7 @@ use Wikibase\DataModel\Term\Term;
 /**
  * @since 1.1
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Katie Filbert < aude.wiki@gmail.com >
  * @author Marius Hoch < hoo@online.de >
  */

--- a/src/Lookup/LabelDescriptionLookupException.php
+++ b/src/Lookup/LabelDescriptionLookupException.php
@@ -9,7 +9,7 @@ use Wikibase\DataModel\Entity\EntityId;
 /**
  * @since 2.0
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Addshore
  */
 class LabelDescriptionLookupException extends RuntimeException {

--- a/src/Lookup/LanguageLabelDescriptionLookup.php
+++ b/src/Lookup/LanguageLabelDescriptionLookup.php
@@ -8,7 +8,7 @@ use Wikibase\DataModel\Term\Term;
 /**
  * @since 1.1
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Katie Filbert < aude.wiki@gmail.com >
  * @author Marius Hoch < hoo@online.de >
  * @author Addshore

--- a/src/Lookup/PropertyDataTypeLookup.php
+++ b/src/Lookup/PropertyDataTypeLookup.php
@@ -7,7 +7,7 @@ use Wikibase\DataModel\Entity\PropertyId;
 /**
  * @since 1.0
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 interface PropertyDataTypeLookup {

--- a/src/Lookup/PropertyDataTypeLookupException.php
+++ b/src/Lookup/PropertyDataTypeLookupException.php
@@ -9,7 +9,7 @@ use Wikibase\DataModel\Entity\PropertyId;
 /**
  * @since 2.0
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Addshore
  */
 class PropertyDataTypeLookupException extends RuntimeException {

--- a/src/Lookup/PropertyLookup.php
+++ b/src/Lookup/PropertyLookup.php
@@ -8,7 +8,7 @@ use Wikibase\DataModel\Entity\PropertyId;
 /**
  * @since 1.0
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Thomas Pellissier Tanon
  */
 interface PropertyLookup {

--- a/src/Lookup/PropertyLookupException.php
+++ b/src/Lookup/PropertyLookupException.php
@@ -8,7 +8,7 @@ use Wikibase\DataModel\Entity\PropertyId;
 /**
  * @since 2.0
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Addshore
  */
 class PropertyLookupException extends EntityLookupException {

--- a/src/Lookup/RedirectResolvingEntityLookup.php
+++ b/src/Lookup/RedirectResolvingEntityLookup.php
@@ -11,7 +11,7 @@ use Wikibase\DataModel\Entity\EntityId;
  *
  * @since 2.0
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Daniel Kinzler
  */
 class RedirectResolvingEntityLookup implements EntityLookup {

--- a/src/Lookup/RestrictedEntityLookup.php
+++ b/src/Lookup/RestrictedEntityLookup.php
@@ -15,7 +15,7 @@ use Wikibase\DataModel\Entity\EntityId;
  *
  * @since 2.0
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Marius Hoch < hoo@online.de >
  */
 class RestrictedEntityLookup implements EntityLookup {

--- a/src/Lookup/TermLookup.php
+++ b/src/Lookup/TermLookup.php
@@ -11,7 +11,7 @@ use Wikibase\DataModel\Entity\EntityId;
  *
  * @since 1.1
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Katie Filbert < aude.wiki@gmail.com >
  */
 interface TermLookup {

--- a/src/Lookup/TermLookupException.php
+++ b/src/Lookup/TermLookupException.php
@@ -9,7 +9,7 @@ use Wikibase\DataModel\Entity\EntityId;
 /**
  * @since 2.0
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Addshore
  */
 class TermLookupException extends RuntimeException {

--- a/src/Lookup/UnknownForeignRepositoryException.php
+++ b/src/Lookup/UnknownForeignRepositoryException.php
@@ -8,7 +8,7 @@ use InvalidArgumentException;
 /**
  * @since 3.7
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  */
 class UnknownForeignRepositoryException extends InvalidArgumentException {
 

--- a/src/Lookup/UnresolvedEntityRedirectException.php
+++ b/src/Lookup/UnresolvedEntityRedirectException.php
@@ -11,7 +11,7 @@ use Wikibase\DataModel\Entity\EntityId;
  *
  * @since 1.1
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Daniel Kinzler
  */
 class UnresolvedEntityRedirectException extends EntityLookupException {

--- a/src/Statement/Filter/DataTypeStatementFilter.php
+++ b/src/Statement/Filter/DataTypeStatementFilter.php
@@ -13,7 +13,7 @@ use Wikibase\DataModel\Statement\StatementFilter;
  *
  * @since 3.2
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Thiemo Kreuz
  */
 class DataTypeStatementFilter implements StatementFilter {

--- a/src/Statement/Filter/NullStatementFilter.php
+++ b/src/Statement/Filter/NullStatementFilter.php
@@ -12,7 +12,7 @@ use Wikibase\DataModel\Statement\StatementFilter;
  *
  * @since 3.2
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Thiemo Kreuz
  */
 class NullStatementFilter implements StatementFilter {

--- a/src/Statement/Filter/PropertySetStatementFilter.php
+++ b/src/Statement/Filter/PropertySetStatementFilter.php
@@ -11,7 +11,7 @@ use Wikibase\DataModel\Statement\StatementFilter;
  *
  * @since 3.2
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Thiemo Kreuz
  */
 class PropertySetStatementFilter implements StatementFilter {

--- a/src/Statement/Grouper/ByPropertyIdStatementGrouper.php
+++ b/src/Statement/Grouper/ByPropertyIdStatementGrouper.php
@@ -7,7 +7,7 @@ use Wikibase\DataModel\Statement\StatementList;
 /**
  * @since 3.2
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Thiemo Kreuz
  */
 class ByPropertyIdStatementGrouper implements StatementGrouper {

--- a/src/Statement/Grouper/FilteringStatementGrouper.php
+++ b/src/Statement/Grouper/FilteringStatementGrouper.php
@@ -10,7 +10,7 @@ use Wikibase\DataModel\Statement\StatementList;
 /**
  * @since 3.2
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Thiemo Kreuz
  */
 class FilteringStatementGrouper implements StatementGrouper {

--- a/src/Statement/Grouper/NullStatementGrouper.php
+++ b/src/Statement/Grouper/NullStatementGrouper.php
@@ -10,7 +10,7 @@ use Wikibase\DataModel\Statement\StatementList;
  *
  * @since 3.2
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Thiemo Kreuz
  */
 class NullStatementGrouper implements StatementGrouper {

--- a/src/Statement/Grouper/StatementGrouper.php
+++ b/src/Statement/Grouper/StatementGrouper.php
@@ -7,7 +7,7 @@ use Wikibase\DataModel\Statement\StatementList;
 /**
  * @since 3.2
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Thiemo Kreuz
  */
 interface StatementGrouper {

--- a/src/Statement/GuidGenerator.php
+++ b/src/Statement/GuidGenerator.php
@@ -8,7 +8,7 @@ use Wikibase\DataModel\Statement\StatementGuid;
 /**
  * @since 1.0
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Daniel Kinzler
  * @author Addshore

--- a/src/Statement/StatementGuidParser.php
+++ b/src/Statement/StatementGuidParser.php
@@ -14,7 +14,7 @@ use Wikibase\DataModel\Statement\StatementGuid;
  *
  * @since 1.0
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Addshore
  */
 class StatementGuidParser {

--- a/src/Statement/StatementGuidParsingException.php
+++ b/src/Statement/StatementGuidParsingException.php
@@ -7,7 +7,7 @@ use RuntimeException;
 /**
  * @since 1.0
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Addshore
  */
 class StatementGuidParsingException extends RuntimeException {

--- a/src/Statement/StatementGuidValidator.php
+++ b/src/Statement/StatementGuidValidator.php
@@ -9,7 +9,7 @@ use Wikibase\DataModel\Statement\StatementGuid;
 /**
  * @since 1.1
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Katie Filbert < aude.wiki@gmail.com >
  */
 class StatementGuidValidator {

--- a/src/Statement/V4GuidGenerator.php
+++ b/src/Statement/V4GuidGenerator.php
@@ -7,7 +7,7 @@ namespace Wikibase\DataModel\Services\Statement;
  *
  * @since 1.0
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class V4GuidGenerator {

--- a/src/Term/PropertyLabelResolver.php
+++ b/src/Term/PropertyLabelResolver.php
@@ -9,7 +9,7 @@ use Wikibase\DataModel\Entity\EntityId;
  *
  * @since 1.1
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Daniel Kinzler
  */
 interface PropertyLabelResolver {

--- a/src/Term/TermBuffer.php
+++ b/src/Term/TermBuffer.php
@@ -9,7 +9,7 @@ use Wikibase\DataModel\Entity\EntityId;
  *
  * @since 1.1
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Daniel Kinzler
  */
 interface TermBuffer {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,7 +3,7 @@
 /**
  * PHPUnit test bootstrap file for the Wikibase DataModel Services component.
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 

--- a/tests/fixtures/EntityOfUnknownType.php
+++ b/tests/fixtures/EntityOfUnknownType.php
@@ -5,7 +5,7 @@ namespace Wikibase\DataModel\Services\Fixtures;
 use Wikibase\DataModel\Entity\EntityDocument;
 
 /**
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class EntityOfUnknownType implements EntityDocument {

--- a/tests/fixtures/FakeEntityDocument.php
+++ b/tests/fixtures/FakeEntityDocument.php
@@ -6,7 +6,7 @@ use Wikibase\DataModel\Entity\EntityDocument;
 use Wikibase\DataModel\Entity\EntityId;
 
 /**
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class FakeEntityDocument implements EntityDocument {

--- a/tests/unit/ByPropertyIdGrouperTest.php
+++ b/tests/unit/ByPropertyIdGrouperTest.php
@@ -14,7 +14,7 @@ use Wikibase\DataModel\Snak\Snak;
 /**
  * @covers Wikibase\DataModel\Services\ByPropertyIdGrouper
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Bene* < benestar.wikimedia@gmail.com >
  * @author Thiemo Kreuz
  */

--- a/tests/unit/DataValue/ValuesFinderTest.php
+++ b/tests/unit/DataValue/ValuesFinderTest.php
@@ -16,7 +16,7 @@ use Wikibase\DataModel\Snak\Snak;
 /**
  * @covers Wikibase\DataModel\Services\DataValue\ValuesFinder
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Bene* < benestar.wikimedia@gmail.com >
  */
 class ValuesFinderTest extends \PHPUnit_Framework_TestCase {

--- a/tests/unit/Diff/EntityDiffOldTest.php
+++ b/tests/unit/Diff/EntityDiffOldTest.php
@@ -12,7 +12,7 @@ use Wikibase\DataModel\Services\Diff\EntityPatcher;
 /**
  * @covers Wikibase\DataModel\Services\Diff\EntityDiff
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Daniel Kinzler
  * @author Jens Ohlig <jens.ohlig@wikimedia.de>
  */

--- a/tests/unit/Diff/EntityDiffTest.php
+++ b/tests/unit/Diff/EntityDiffTest.php
@@ -17,7 +17,7 @@ use Wikibase\DataModel\Statement\StatementList;
 /**
  * @covers Wikibase\DataModel\Services\Diff\EntityDiff
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class EntityDiffTest extends PHPUnit_Framework_TestCase {

--- a/tests/unit/Diff/EntityDifferTest.php
+++ b/tests/unit/Diff/EntityDifferTest.php
@@ -13,7 +13,7 @@ use Wikibase\DataModel\Services\Diff\EntityDiffer;
 /**
  * @covers Wikibase\DataModel\Services\Diff\EntityDiffer
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class EntityDifferTest extends \PHPUnit_Framework_TestCase {

--- a/tests/unit/Diff/EntityPatcherTest.php
+++ b/tests/unit/Diff/EntityPatcherTest.php
@@ -13,7 +13,7 @@ use Wikibase\DataModel\Services\Fixtures\EntityOfUnknownType;
 /**
  * @covers Wikibase\DataModel\Services\Diff\EntityPatcher
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Christoph Fischer < christoph.fischer@wikimedia.de >
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */

--- a/tests/unit/Diff/EntityTypeAwareDiffOpFactoryTest.php
+++ b/tests/unit/Diff/EntityTypeAwareDiffOpFactoryTest.php
@@ -10,7 +10,7 @@ use Wikibase\DataModel\Services\Diff\ItemDiff;
 /**
  * @covers Wikibase\DataModel\Services\Diff\EntityTypeAwareDiffOpFactory
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class EntityTypeAwareDiffOpFactoryTest extends \PHPUnit_Framework_TestCase {

--- a/tests/unit/Diff/Internal/AliasGroupListPatcherTest.php
+++ b/tests/unit/Diff/Internal/AliasGroupListPatcherTest.php
@@ -14,7 +14,7 @@ use Wikibase\DataModel\Term\AliasGroupList;
 /**
  * @covers Wikibase\DataModel\Services\Diff\Internal\AliasGroupListPatcher
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Bene* < benestar.wikimedia@gmail.com >
  */
 class AliasGroupListPatcherTest extends PHPUnit_Framework_TestCase {

--- a/tests/unit/Diff/Internal/FingerprintPatcherTest.php
+++ b/tests/unit/Diff/Internal/FingerprintPatcherTest.php
@@ -13,7 +13,7 @@ use Wikibase\DataModel\Term\Fingerprint;
 /**
  * @covers Wikibase\DataModel\Services\Diff\Internal\FingerprintPatcher
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Thiemo Kreuz
  */

--- a/tests/unit/Diff/Internal/SiteLinkListPatcherTest.php
+++ b/tests/unit/Diff/Internal/SiteLinkListPatcherTest.php
@@ -13,7 +13,7 @@ use Wikibase\DataModel\SiteLinkList;
 /**
  * @covers Wikibase\DataModel\Services\Diff\Internal\SiteLinkListPatcher
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class SiteLinkListPatcherTest extends \PHPUnit_Framework_TestCase {

--- a/tests/unit/Diff/ItemDiffTest.php
+++ b/tests/unit/Diff/ItemDiffTest.php
@@ -15,7 +15,7 @@ use Wikibase\DataModel\SiteLink;
 /**
  * @covers Wikibase\DataModel\Services\Diff\ItemDiff
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Daniel Kinzler
  * @author Jens Ohlig <jens.ohlig@wikimedia.de>
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >

--- a/tests/unit/Diff/ItemDifferTest.php
+++ b/tests/unit/Diff/ItemDifferTest.php
@@ -15,7 +15,7 @@ use Wikibase\DataModel\Snak\PropertySomeValueSnak;
  * @covers Wikibase\DataModel\Services\Diff\ItemDiffer
  * @covers Wikibase\DataModel\Services\Diff\ItemDiff
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class ItemDifferTest extends \PHPUnit_Framework_TestCase {

--- a/tests/unit/Diff/ItemPatcherTest.php
+++ b/tests/unit/Diff/ItemPatcherTest.php
@@ -19,7 +19,7 @@ use Wikibase\DataModel\Statement\Statement;
 /**
  * @covers Wikibase\DataModel\Services\Diff\ItemPatcher
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class ItemPatcherTest extends PHPUnit_Framework_TestCase {

--- a/tests/unit/Diff/PropertyDifferTest.php
+++ b/tests/unit/Diff/PropertyDifferTest.php
@@ -9,7 +9,7 @@ use Wikibase\DataModel\Snak\PropertySomeValueSnak;
 /**
  * @covers Wikibase\DataModel\Services\Diff\PropertyDiffer
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class PropertyDifferTest extends \PHPUnit_Framework_TestCase {

--- a/tests/unit/Diff/PropertyPatcherTest.php
+++ b/tests/unit/Diff/PropertyPatcherTest.php
@@ -18,7 +18,7 @@ use Wikibase\DataModel\Statement\Statement;
 /**
  * @covers Wikibase\DataModel\Services\Diff\PropertyPatcher
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class PropertyPatcherTest extends PHPUnit_Framework_TestCase {

--- a/tests/unit/Diff/StatementListDifferTest.php
+++ b/tests/unit/Diff/StatementListDifferTest.php
@@ -15,7 +15,7 @@ use Wikibase\DataModel\Statement\StatementList;
 /**
  * @covers Wikibase\DataModel\Services\Diff\StatementListDiffer
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class StatementListDifferTest extends \PHPUnit_Framework_TestCase {

--- a/tests/unit/Diff/StatementListPatcherTest.php
+++ b/tests/unit/Diff/StatementListPatcherTest.php
@@ -17,7 +17,7 @@ use Wikibase\DataModel\Statement\StatementList;
 /**
  * @covers Wikibase\DataModel\Services\Diff\StatementListPatcher
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Thiemo Kreuz
  */

--- a/tests/unit/Diff/TermListPatcherTest.php
+++ b/tests/unit/Diff/TermListPatcherTest.php
@@ -14,7 +14,7 @@ use Wikibase\DataModel\Term\TermList;
 /**
  * @covers Wikibase\DataModel\Services\Diff\TermListPatcher
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Bene* < benestar.wikimedia@gmail.com >
  */
 class TermListPatcherTest extends PHPUnit_Framework_TestCase {

--- a/tests/unit/Entity/PropertyDataTypeMatcherTest.php
+++ b/tests/unit/Entity/PropertyDataTypeMatcherTest.php
@@ -11,7 +11,7 @@ use Wikibase\DataModel\Services\Entity\PropertyDataTypeMatcher;
 /**
  * @covers Wikibase\DataModel\Services\Entity\PropertyDataTypeMatcher
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Katie Filbert < aude.wiki@gmail.com >
  */
 class PropertyDataTypeMatcherTest extends PHPUnit_Framework_TestCase {

--- a/tests/unit/EntityId/EntityIdLabelFormatterTest.php
+++ b/tests/unit/EntityId/EntityIdLabelFormatterTest.php
@@ -14,7 +14,7 @@ use Wikibase\DataModel\Term\Term;
 /**
  * @covers Wikibase\DataModel\Services\EntityId\EntityIdLabelFormatter
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Daniel Kinzler
  * @author Katie Filbert < aude.wiki@gmail.com >

--- a/tests/unit/EntityId/EscapingEntityIdFormatterTest.php
+++ b/tests/unit/EntityId/EscapingEntityIdFormatterTest.php
@@ -10,7 +10,7 @@ use Wikibase\DataModel\Services\EntityId\EscapingEntityIdFormatter;
 /**
  * @covers Wikibase\DataModel\Services\EntityId\EscapingEntityIdFormatter
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Daniel Kinzler
  */
 class EscapingEntityIdFormatterTest extends PHPUnit_Framework_TestCase {

--- a/tests/unit/EntityId/PlainEntityIdFormatterTest.php
+++ b/tests/unit/EntityId/PlainEntityIdFormatterTest.php
@@ -11,7 +11,7 @@ use Wikibase\DataModel\Services\EntityId\PlainEntityIdFormatter;
 /**
  * @covers Wikibase\DataModel\Services\EntityId\PlainEntityIdFormatter
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class PlainEntityIdFormatterTest extends PHPUnit_Framework_TestCase {

--- a/tests/unit/EntityId/PrefixMappingEntityIdParserFactoryTest.php
+++ b/tests/unit/EntityId/PrefixMappingEntityIdParserFactoryTest.php
@@ -11,7 +11,7 @@ use Wikimedia\Assert\ParameterTypeException;
 /**
  * @covers Wikibase\DataModel\Services\EntityId\PrefixMappingEntityIdParserFactory
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  */
 class PrefixMappingEntityIdParserFactoryTest extends \PHPUnit_Framework_TestCase {
 

--- a/tests/unit/EntityId/PrefixMappingEntityIdParserTest.php
+++ b/tests/unit/EntityId/PrefixMappingEntityIdParserTest.php
@@ -15,7 +15,7 @@ use Wikimedia\Assert\ParameterAssertionException;
 /**
  * @covers Wikibase\DataModel\Services\EntityId\PrefixMappingEntityIdParser
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  */
 class PrefixMappingEntityIdParserTest extends \PHPUnit_Framework_TestCase {
 

--- a/tests/unit/EntityId/SuffixEntityIdParserTest.php
+++ b/tests/unit/EntityId/SuffixEntityIdParserTest.php
@@ -11,7 +11,7 @@ use Wikibase\DataModel\Services\EntityId\SuffixEntityIdParser;
 /**
  * @covers Wikibase\DataModel\Services\EntityId\SuffixEntityIdParser
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Daniel Kinzler
  */
 class SuffixEntityIdParserTest extends \PHPUnit_Framework_TestCase {

--- a/tests/unit/Lookup/DisabledEntityTypesEntityLookupTest.php
+++ b/tests/unit/Lookup/DisabledEntityTypesEntityLookupTest.php
@@ -11,7 +11,7 @@ use Wikibase\DataModel\Services\Lookup\EntityLookupException;
 /**
  * @covers Wikibase\DataModel\Services\Lookup\DisabledEntityTypesEntityLookup
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Amir Sarabadani
  */
 class DisabledEntityTypesEntityLookupTest extends \PHPUnit_Framework_TestCase {

--- a/tests/unit/Lookup/DispatchingEntityLookupTest.php
+++ b/tests/unit/Lookup/DispatchingEntityLookupTest.php
@@ -15,7 +15,7 @@ use Wikimedia\Assert\ParameterAssertionException;
 /**
  * @covers Wikibase\DataModel\Services\Lookup\DispatchingEntityLookup
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  */
 class DispatchingEntityLookupTest extends \PHPUnit_Framework_TestCase {
 

--- a/tests/unit/Lookup/EntityLookupExceptionTest.php
+++ b/tests/unit/Lookup/EntityLookupExceptionTest.php
@@ -8,7 +8,7 @@ use Wikibase\DataModel\Services\Lookup\EntityLookupException;
 /**
  * @covers Wikibase\DataModel\Services\Lookup\EntityLookupException
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Addshore
  */
 class EntityLookupExceptionTest extends \PHPUnit_Framework_TestCase {

--- a/tests/unit/Lookup/EntityRedirectLookupExceptionTest.php
+++ b/tests/unit/Lookup/EntityRedirectLookupExceptionTest.php
@@ -10,7 +10,7 @@ use Wikibase\DataModel\Services\Lookup\EntityRedirectLookupException;
 /**
  * @covers Wikibase\DataModel\Services\Lookup\EntityRedirectLookupException
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Thiemo Kreuz
  */
 class EntityRedirectLookupExceptionTest extends PHPUnit_Framework_TestCase {

--- a/tests/unit/Lookup/EntityRetrievingDataTypeLookupTest.php
+++ b/tests/unit/Lookup/EntityRetrievingDataTypeLookupTest.php
@@ -11,7 +11,7 @@ use Wikibase\DataModel\Services\Lookup\InMemoryEntityLookup;
 /**
  * @covers Wikibase\DataModel\Services\Lookup\EntityRetrievingDataTypeLookup
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class EntityRetrievingDataTypeLookupTest extends \PHPUnit_Framework_TestCase {

--- a/tests/unit/Lookup/EntityRetrievingTermLookupTest.php
+++ b/tests/unit/Lookup/EntityRetrievingTermLookupTest.php
@@ -13,7 +13,7 @@ use Wikibase\DataModel\Services\Lookup\TermLookupException;
 /**
  * @covers Wikibase\DataModel\Services\Lookup\EntityRetrievingTermLookup
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Katie Filbert < aude.wiki@gmail.com >
  * @author Daniel Kinzler
  */

--- a/tests/unit/Lookup/InMemoryDataTypeLookupTest.php
+++ b/tests/unit/Lookup/InMemoryDataTypeLookupTest.php
@@ -9,7 +9,7 @@ use Wikibase\DataModel\Services\Lookup\PropertyDataTypeLookupException;
 /**
  * @covers Wikibase\DataModel\Services\Lookup\InMemoryDataTypeLookup
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class InMemoryDataTypeLookupTest extends \PHPUnit_Framework_TestCase {

--- a/tests/unit/Lookup/InMemoryEntityLookupTest.php
+++ b/tests/unit/Lookup/InMemoryEntityLookupTest.php
@@ -10,7 +10,7 @@ use Wikibase\DataModel\Services\Lookup\InMemoryEntityLookup;
 /**
  * @covers Wikibase\DataModel\Services\Lookup\InMemoryEntityLookup
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class InMemoryEntityLookupTest extends \PHPUnit_Framework_TestCase {

--- a/tests/unit/Lookup/InProcessCachingDataTypeLookupTest.php
+++ b/tests/unit/Lookup/InProcessCachingDataTypeLookupTest.php
@@ -10,7 +10,7 @@ use Wikibase\DataModel\Services\Lookup\PropertyDataTypeLookup;
 /**
  * @covers Wikibase\DataModel\Services\Lookup\InProcessCachingDataTypeLookup
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Katie Filbert < aude.wiki@gmail.com >
  */
 class InProcessCachingDataTypeLookupTest extends PHPUnit_Framework_TestCase {

--- a/tests/unit/Lookup/ItemLookupExceptionTest.php
+++ b/tests/unit/Lookup/ItemLookupExceptionTest.php
@@ -8,7 +8,7 @@ use Wikibase\DataModel\Services\Lookup\ItemLookupException;
 /**
  * @covers Wikibase\DataModel\Services\Lookup\ItemLookupException
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Addshore
  */
 class ItemLookupExceptionTest extends \PHPUnit_Framework_TestCase {

--- a/tests/unit/Lookup/LabelDescriptionLookupExceptionTest.php
+++ b/tests/unit/Lookup/LabelDescriptionLookupExceptionTest.php
@@ -10,7 +10,7 @@ use Wikibase\DataModel\Services\Lookup\LabelDescriptionLookupException;
 /**
  * @covers Wikibase\DataModel\Services\Lookup\LabelDescriptionLookupException
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Thiemo Kreuz
  */
 class LabelDescriptionLookupExceptionTest extends PHPUnit_Framework_TestCase {

--- a/tests/unit/Lookup/LanguageLabelDescriptionLookupTest.php
+++ b/tests/unit/Lookup/LanguageLabelDescriptionLookupTest.php
@@ -10,7 +10,7 @@ use Wikibase\DataModel\Term\Term;
 /**
  * @covers Wikibase\DataModel\Services\Lookup\LanguageLabelDescriptionLookup
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class LanguageLabelDescriptionLookupTest extends \PHPUnit_Framework_TestCase {

--- a/tests/unit/Lookup/PropertyDataTypeLookupExceptionTest.php
+++ b/tests/unit/Lookup/PropertyDataTypeLookupExceptionTest.php
@@ -10,7 +10,7 @@ use Wikibase\DataModel\Services\Lookup\PropertyDataTypeLookupException;
 /**
  * @covers Wikibase\DataModel\Services\Lookup\PropertyDataTypeLookupException
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Thiemo Kreuz
  */
 class PropertyDataTypeLookupExceptionTest extends PHPUnit_Framework_TestCase {

--- a/tests/unit/Lookup/PropertyLookupExceptionTest.php
+++ b/tests/unit/Lookup/PropertyLookupExceptionTest.php
@@ -8,7 +8,7 @@ use Wikibase\DataModel\Services\Lookup\PropertyLookupException;
 /**
  * @covers Wikibase\DataModel\Services\Lookup\PropertyLookupException
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Addshore
  */
 class PropertyLookupExceptionTest extends \PHPUnit_Framework_TestCase {

--- a/tests/unit/Lookup/RedirectResolvingEntityLookupTest.php
+++ b/tests/unit/Lookup/RedirectResolvingEntityLookupTest.php
@@ -12,7 +12,7 @@ use Wikibase\DataModel\Services\Lookup\UnresolvedEntityRedirectException;
 /**
  * @covers Wikibase\DataModel\Services\Lookup\RedirectResolvingEntityLookup
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Daniel Kinzler
  */
 class RedirectResolvingEntityLookupTest extends \PHPUnit_Framework_TestCase {

--- a/tests/unit/Lookup/RestrictedEntityLookupTest.php
+++ b/tests/unit/Lookup/RestrictedEntityLookupTest.php
@@ -11,7 +11,7 @@ use Wikibase\DataModel\Services\Lookup\RestrictedEntityLookup;
 /**
  * @covers Wikibase\DataModel\Services\Lookup\RestrictedEntityLookup
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Marius Hoch
  */
 class RestrictedEntityLookupTest extends \PHPUnit_Framework_TestCase {

--- a/tests/unit/Lookup/TermLookupExceptionTest.php
+++ b/tests/unit/Lookup/TermLookupExceptionTest.php
@@ -10,7 +10,7 @@ use Wikibase\DataModel\Services\Lookup\TermLookupException;
 /**
  * @covers Wikibase\DataModel\Services\Lookup\TermLookupException
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Thiemo Kreuz
  */
 class TermLookupExceptionTest extends PHPUnit_Framework_TestCase {

--- a/tests/unit/Lookup/UnknownForeignRepositoryExceptionTest.php
+++ b/tests/unit/Lookup/UnknownForeignRepositoryExceptionTest.php
@@ -8,7 +8,7 @@ use Wikibase\DataModel\Services\Lookup\UnknownForeignRepositoryException;
 /**
  * @covers Wikibase\DataModel\Services\Lookup\UnknownForeignRepositoryException
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  */
 class UnknownForeignRepositoryExceptionTest extends \PHPUnit_Framework_TestCase {
 

--- a/tests/unit/Lookup/UnresolvedEntityRedirectExceptionTest.php
+++ b/tests/unit/Lookup/UnresolvedEntityRedirectExceptionTest.php
@@ -10,7 +10,7 @@ use Wikibase\DataModel\Services\Lookup\UnresolvedEntityRedirectException;
 /**
  * @covers Wikibase\DataModel\Services\Lookup\UnresolvedEntityRedirectException
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Thiemo Kreuz
  */
 class UnresolvedEntityRedirectExceptionTest extends PHPUnit_Framework_TestCase {

--- a/tests/unit/Statement/Filter/DataTypeStatementFilterTest.php
+++ b/tests/unit/Statement/Filter/DataTypeStatementFilterTest.php
@@ -13,7 +13,7 @@ use Wikibase\DataModel\Statement\Statement;
 /**
  * @covers Wikibase\DataModel\Services\Statement\Filter\DataTypeStatementFilter
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Thiemo Kreuz
  */
 class DataTypeStatementFilterTest extends PHPUnit_Framework_TestCase {

--- a/tests/unit/Statement/Filter/NullStatementFilterTest.php
+++ b/tests/unit/Statement/Filter/NullStatementFilterTest.php
@@ -10,7 +10,7 @@ use Wikibase\DataModel\Statement\Statement;
 /**
  * @covers Wikibase\DataModel\Services\Statement\Filter\NullStatementFilter
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Thiemo Kreuz
  */
 class NullStatementFilterTest extends PHPUnit_Framework_TestCase {

--- a/tests/unit/Statement/Filter/PropertySetStatementFilterTest.php
+++ b/tests/unit/Statement/Filter/PropertySetStatementFilterTest.php
@@ -10,7 +10,7 @@ use Wikibase\DataModel\Statement\Statement;
 /**
  * @covers Wikibase\DataModel\Services\Statement\Filter\PropertySetStatementFilter
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Thiemo Kreuz
  */
 class PropertySetStatementFilterTest extends PHPUnit_Framework_TestCase {

--- a/tests/unit/Statement/Grouper/ByPropertyIdStatementGrouperTest.php
+++ b/tests/unit/Statement/Grouper/ByPropertyIdStatementGrouperTest.php
@@ -11,7 +11,7 @@ use Wikibase\DataModel\Statement\StatementList;
 /**
  * @covers Wikibase\DataModel\Services\Statement\Grouper\ByPropertyIdStatementGrouper
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Thiemo Kreuz
  */
 class ByPropertyIdStatementGrouperTest extends PHPUnit_Framework_TestCase {

--- a/tests/unit/Statement/Grouper/FilteringStatementGrouperTest.php
+++ b/tests/unit/Statement/Grouper/FilteringStatementGrouperTest.php
@@ -13,7 +13,7 @@ use Wikibase\DataModel\Statement\StatementList;
 /**
  * @covers Wikibase\DataModel\Services\Statement\Grouper\FilteringStatementGrouper
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Thiemo Kreuz
  */
 class FilteringStatementGrouperTest extends PHPUnit_Framework_TestCase {

--- a/tests/unit/Statement/Grouper/NullStatementGrouperTest.php
+++ b/tests/unit/Statement/Grouper/NullStatementGrouperTest.php
@@ -10,7 +10,7 @@ use Wikibase\DataModel\Statement\StatementList;
 /**
  * @covers Wikibase\DataModel\Services\Statement\Grouper\NullStatementGrouper
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Thiemo Kreuz
  */
 class NullStatementGrouperTest extends PHPUnit_Framework_TestCase {

--- a/tests/unit/Statement/GuidGeneratorTest.php
+++ b/tests/unit/Statement/GuidGeneratorTest.php
@@ -10,7 +10,7 @@ use Wikibase\DataModel\Services\Statement\GuidGenerator;
 /**
  * @covers Wikibase\DataModel\Services\Statement\GuidGenerator
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class GuidGeneratorTest extends \PHPUnit_Framework_TestCase {

--- a/tests/unit/Statement/StatementGuidParserTest.php
+++ b/tests/unit/Statement/StatementGuidParserTest.php
@@ -11,7 +11,7 @@ use Wikibase\DataModel\Statement\StatementGuid;
 /**
  * @covers Wikibase\DataModel\Services\Statement\StatementGuidParser
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Addshore
  */
 class StatementGuidParserTest extends \PHPUnit_Framework_TestCase {

--- a/tests/unit/Statement/StatementGuidValidatorTest.php
+++ b/tests/unit/Statement/StatementGuidValidatorTest.php
@@ -8,7 +8,7 @@ use Wikibase\DataModel\Services\Statement\StatementGuidValidator;
 /**
  * @covers Wikibase\DataModel\Services\Statement\StatementGuidValidator
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Katie Filbert < aude.wiki@gmail.com >
  */
 class StatementGuidValidatorTest extends \PHPUnit_Framework_TestCase {

--- a/tests/unit/Statement/V4GuidGeneratorTest.php
+++ b/tests/unit/Statement/V4GuidGeneratorTest.php
@@ -7,7 +7,7 @@ use Wikibase\DataModel\Services\Statement\V4GuidGenerator;
 /**
  * @covers Wikibase\DataModel\Services\Statement\V4GuidGenerator
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Addshore
  */
 class V4GuidGeneratorTest extends \PHPUnit_Framework_TestCase {


### PR DESCRIPTION
The only change is an update to all `@license` tags, to match the new SPDX version.

~~I'm also removing the ArrayBracketSpacing sniff from this local rule set, because the code style enforced by this sniff (it *forbids* to use spaces in `$array[$key]`) clashes with the MediaWiki core code style that suggests to add these spaces.~~