### PR TITLE
Add vararg constructor to InMemoryEntityLookup

### DIFF
--- a/src/Lookup/InMemoryEntityLookup.php
+++ b/src/Lookup/InMemoryEntityLookup.php
@@ -31,6 +31,15 @@ class InMemoryEntityLookup implements EntityLookup {
 	private $exceptions = [];
 
 	/**
+	 * @param EntityDocument ...$entities
+	 */
+	public function __construct( ...$entities ) {
+		foreach ( $entities as $entity ) {
+			$this->addEntity( $entity );
+		}
+	}
+
+	/**
 	 * @param EntityDocument $entity
 	 *
 	 * @throws InvalidArgumentException

--- a/tests/fixtures/FakeEntityDocument.php
+++ b/tests/fixtures/FakeEntityDocument.php
@@ -12,16 +12,16 @@ use Wikibase\DataModel\Entity\EntityId;
 class FakeEntityDocument implements EntityDocument {
 
 	/**
-	 * @var EntityId
+	 * @var EntityId|null
 	 */
 	private $id;
 
-	public function __construct( EntityId $id ) {
+	public function __construct( EntityId $id = null ) {
 		$this->id = $id;
 	}
 
 	/**
-	 * @return EntityId
+	 * @return EntityId|null
 	 */
 	public function getId() {
 		return $this->id;

--- a/tests/unit/Lookup/InMemoryEntityLookupTest.php
+++ b/tests/unit/Lookup/InMemoryEntityLookupTest.php
@@ -2,13 +2,14 @@
 
 namespace Wikibase\DataModel\Services\Tests\Lookup;
 
+use InvalidArgumentException;
 use Wikibase\DataModel\Entity\ItemId;
 use Wikibase\DataModel\Services\Fixtures\FakeEntityDocument;
 use Wikibase\DataModel\Services\Lookup\EntityLookupException;
 use Wikibase\DataModel\Services\Lookup\InMemoryEntityLookup;
 
 /**
- * @covers Wikibase\DataModel\Services\Lookup\InMemoryEntityLookup
+ * @covers \Wikibase\DataModel\Services\Lookup\InMemoryEntityLookup
  *
  * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
@@ -54,7 +55,7 @@ class InMemoryEntityLookupTest extends \PHPUnit_Framework_TestCase {
 		$lookup->addException( new EntityLookupException( new ItemId( 'Q1' ) ) );
 
 		$lookup->getEntity( new ItemId( 'Q2' ) );
-		$this->setExpectedException( EntityLookupException::class );
+		$this->expectException( EntityLookupException::class );
 		$lookup->getEntity( new ItemId( 'Q1' ) );
 	}
 
@@ -64,8 +65,26 @@ class InMemoryEntityLookupTest extends \PHPUnit_Framework_TestCase {
 		$lookup->addException( new EntityLookupException( new ItemId( 'Q1' ) ) );
 
 		$lookup->hasEntity( new ItemId( 'Q2' ) );
-		$this->setExpectedException( EntityLookupException::class );
+		$this->expectException( EntityLookupException::class );
 		$lookup->hasEntity( new ItemId( 'Q1' ) );
+	}
+
+	public function testGivenConstructorVarArgEntities_theyCanBeRetrieved() {
+		$lookup = new InMemoryEntityLookup(
+			new FakeEntityDocument( new ItemId( 'Q1' ) ),
+			new FakeEntityDocument( new ItemId( 'Q2' ) )
+		);
+
+		$this->assertTrue( $lookup->hasEntity( new ItemId( 'Q1' ) ) );
+		$this->assertTrue( $lookup->hasEntity( new ItemId( 'Q2' ) ) );
+	}
+
+	public function testGivenEntityWithoutIdInConstructor_exceptionIsThrown() {
+		$this->expectException( InvalidArgumentException::class );
+
+		new InMemoryEntityLookup(
+			new FakeEntityDocument()
+		);
 	}
 
 }


### PR DESCRIPTION
Noticed absence in
https://gerrit.wikimedia.org/r/c/mediawiki/extensions/WikibaseQualityConstraints/+/473719/1/tests/phpunit/Helper/ExceptionIgnoringEntityLookupTest.php