### PR TITLE
Drop hhvm from travis because broken

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ matrix:
   fast_finish: true
   include:
     - env: DM=~6.3
-      php: hhvm
-    - env: DM=~7.5
       php: 5.6
     - env: DM=~7.5
       php: 7


### PR DESCRIPTION
All new PRs are red now:
* https://github.com/wmde/WikibaseDataModelServices/pull/205
* https://github.com/wmde/WikibaseDataModelServices/pull/204