### PR TITLE
Add ExceptionIgnoringEntityLookup

### DIFF
--- a/src/Lookup/ExceptionIgnoringEntityLookup.php
+++ b/src/Lookup/ExceptionIgnoringEntityLookup.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Lookup;
+
+use Wikibase\DataModel\Entity\EntityDocument;
+use Wikibase\DataModel\Entity\EntityId;
+
+/**
+ * An {@link EntityLookup} which ignores any exceptions
+ * which occur while retrieving an entity
+ * and instead pretends the entity does not exist.
+ *
+ * @license GPL-2.0-or-later
+ */
+class ExceptionIgnoringEntityLookup implements EntityLookup {
+
+	/**
+	 * @var EntityLookup
+	 */
+	private $lookup;
+
+	public function __construct( EntityLookup $lookup ) {
+		$this->lookup = $lookup;
+	}
+
+	/**
+	 * Attempt to retrieve the entity,
+	 * returning `null` if any errors occur.
+	 *
+	 * @param EntityId $entityId
+	 * @return EntityDocument|null
+	 */
+	public function getEntity( EntityId $entityId ) {
+		try {
+			return $this->lookup->getEntity( $entityId );
+		} catch ( EntityLookupException $exception ) {
+			return null;
+		}
+	}
+
+	/**
+	 * Returns whether the given entity can potentially be looked up using {@link getEntity()}.
+	 * Note that this does not guarantee {@link getEntity()} will return an {@link EntityDocument} –
+	 * it may still return `null` if an error occurs retrieving the entity.
+	 *
+	 * @param EntityId $entityId
+	 * @return bool
+	 */
+	public function hasEntity( EntityId $entityId ) {
+		return $this->lookup->hasEntity( $entityId );
+	}
+
+}

--- a/tests/unit/Lookup/ExceptionIgnoringEntityLookupTest.php
+++ b/tests/unit/Lookup/ExceptionIgnoringEntityLookupTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Tests\Lookup;
+
+use Wikibase\DataModel\Entity\Item;
+use Wikibase\DataModel\Entity\ItemId;
+use Wikibase\DataModel\Services\Lookup\EntityLookup;
+use Wikibase\DataModel\Services\Lookup\UnresolvedEntityRedirectException;
+use Wikibase\DataModel\Services\Lookup\ExceptionIgnoringEntityLookup;
+
+/**
+ * @covers Wikibase\DataModel\Services\Lookup\ExceptionIgnoringEntityLookup
+ *
+ * @license GPL-2.0-or-later
+ */
+class ExceptionIgnoringEntityLookupTest extends \PHPUnit_Framework_TestCase {
+
+	public function testGetEntity_returnsEntity() {
+		$entity = new Item( new ItemId( 'Q1' ) );
+		$entityId = $entity->getId();
+		$innerLookup = $this->createMock( EntityLookup::class );
+		$innerLookup->expects( $this->once() )
+			->method( 'getEntity' )
+			->with( $entityId )
+			->willReturn( $entity );
+		$outerLookup = new ExceptionIgnoringEntityLookup( $innerLookup );
+
+		$actual = $outerLookup->getEntity( $entityId );
+
+		$this->assertSame( $entity, $actual );
+	}
+
+	public function testGetEntity_returnsNull() {
+		$entityId = new ItemId( 'Q999999999' );
+		$innerLookup = $this->createMock( EntityLookup::class );
+		$innerLookup->expects( $this->once() )
+			->method( 'getEntity' )
+			->with( $entityId )
+			->willReturn( null );
+		$outerLookup = new ExceptionIgnoringEntityLookup( $innerLookup );
+
+		$actual = $outerLookup->getEntity( $entityId );
+
+		$this->assertNull( $actual );
+	}
+
+	public function testGetEntity_catchesUnresolvedEntityRedirectException() {
+		$entityId = new ItemId( 'Q2' );
+		$innerLookup = $this->createMock( EntityLookup::class );
+		$innerLookup->expects( $this->once() )
+			->method( 'getEntity' )
+			->with( $entityId )
+			->willThrowException( new UnresolvedEntityRedirectException(
+				$entityId,
+				new ItemId( 'Q1' )
+			) );
+		$outerLookup = new ExceptionIgnoringEntityLookup( $innerLookup );
+
+		$actual = $outerLookup->getEntity( $entityId );
+
+		$this->assertNull( $actual );
+	}
+
+	/**
+	 * @dataProvider provideBooleans
+	 */
+	public function testHasEntity( $expected ) {
+		$entityId = new ItemId( 'Q1' );
+		$innerLookup = $this->createMock( EntityLookup::class );
+		$innerLookup->expects( $this->once() )
+			->method( 'hasEntity' )
+			->with( $entityId )
+			->willReturn( $expected );
+		$outerLookup = new ExceptionIgnoringEntityLookup( $innerLookup );
+
+		$actual = $outerLookup->hasEntity( $entityId );
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	public function provideBooleans() {
+		return [
+			[ true ],
+			[ false ],
+		];
+	}
+
+}


### PR DESCRIPTION
This was originally implemented for the WikibaseQualityConstraints extension as part of [T93273][1], but seems like a component that could be generally useful.

[1]: https://phabricator.wikimedia.org/T93273