### PR TITLE
Update wikimedia/assert, minimum PHP version

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,4 +1,7 @@
-build: true
+build:
+    environment:
+        php: 7.2
+
 inherit: true
 
 before_commands:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ matrix:
     - env: DM=~6.3
       php: hhvm
     - env: DM=~7.5
-      php: 5.6
-    - env: DM=~7.5
       php: 7
     - env: DM=~8.0
       php: 7.1

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
 		"wikibase/data-model": "~9.0|~8.0|~7.0|~6.3",
 		"data-values/data-values": "~2.0|~1.0",
 		"diff/diff": "~2.3",
-		"wikimedia/assert": "~0.4.0"
+		"wikimedia/assert": "~0.2.2|~0.3.0|~0.4.0"
 	},
 	"require-dev": {
 		"phpmd/phpmd": "~2.3",

--- a/composer.json
+++ b/composer.json
@@ -24,11 +24,11 @@
 		"irc": "irc://irc.freenode.net/wikidata"
 	},
 	"require": {
-		"php": ">=5.6.0",
+		"php": ">=5.6.99",
 		"wikibase/data-model": "~9.0|~8.0|~7.0|~6.3",
 		"data-values/data-values": "~2.0|~1.0",
 		"diff/diff": "~2.3",
-		"wikimedia/assert": "~0.2.2"
+		"wikimedia/assert": "~0.4.0"
 	},
 	"require-dev": {
 		"phpmd/phpmd": "~2.3",


### PR DESCRIPTION
Upgrade wikimedia/assert to 0.4.0 (no major changes but needed to avoid incompatible dependencies in mediawiki/vendor). Upgrade PHP requirement to 7.x or HHVM (needed by wikimedia/assert 0.4 and the end-of-life for 5.6 was January 1, anyway).