### PR TITLE
3.13 release

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,10 @@
 # Wikibase DataModel Services release notes
 
+## Version 3.13.0 (2019-02-05)
+
+* Added ExceptionIgnoringEntityLookup
+* Bumped minimum PHP requirement to 7.x or HHVM
+
 ## Version 3.12.0 (2018-11-06)
 
 * Added compatibility with Wikibase DataModel 9.x

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "3.12.x-dev"
+			"dev-master": "3.13.x-dev"
 		}
 	},
 	"scripts": {


### PR DESCRIPTION
New release with the upped PHP version requirement that makes this library compatible with the new release of wikimedia/assert.