### PR TITLE
Add SeekableEntityIdPager

### DIFF
--- a/src/EntityId/InMemoryEntityIdPager.php
+++ b/src/EntityId/InMemoryEntityIdPager.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Wikibase\DataModel\Services\EntityId;
+
+use Wikibase\DataModel\Entity\EntityId;
+
+/**
+ * The position markers are implementation dependent and are not
+ * interchangeable between different implementations.
+ *
+ * @since 3.14
+ *
+ * @author Addshore
+ * @author Jeroen De Dauw
+ * @license GPL-2.0-or-later
+ */
+class InMemoryEntityIdPager implements SeekableEntityIdPager {
+
+	/**
+	 * @var EntityId[]
+	 */
+	private $entityIds = [];
+
+	/**
+	 * @var int
+	 */
+	private $offset = 0;
+
+	/**
+	 * @param EntityId ...$ids
+	 */
+	public function __construct( ...$ids ) {
+		$this->entityIds = $ids;
+	}
+
+	public function addEntityId( EntityId $entityId ) {
+		$this->entityIds[] = $entityId;
+	}
+
+	/**
+	 * @see EntityIdPager::fetchIds
+	 *
+	 * @param int $limit
+	 *
+	 * @return EntityId[]
+	 */
+	public function fetchIds( $limit ) {
+		$entityIds = array_slice( $this->entityIds, $this->offset, $limit );
+		$this->offset += count( $entityIds );
+		return $entityIds;
+	}
+
+	public function getPosition() {
+		return $this->offset;
+	}
+
+	public function setPosition( $position ) {
+		$this->offset = $position;
+	}
+
+}

--- a/src/EntityId/SeekableEntityIdPager.php
+++ b/src/EntityId/SeekableEntityIdPager.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Wikibase\DataModel\Services\EntityId;
+
+/**
+ * The position markers are implementation dependent and are not
+ * interchangeable between different implementations.
+ *
+ * @since 3.14
+ *
+ * @license GPL-2.0-or-later
+ */
+interface SeekableEntityIdPager extends EntityIdPager {
+
+	/**
+	 * @return mixed Round trips with method setPosition
+	 */
+	public function getPosition();
+
+	/**
+	 * @param mixed $position Round trips with method getPosition
+	 */
+	public function setPosition( $position );
+
+}

--- a/tests/unit/EntityId/InMemoryEntityIdPagerTest.php
+++ b/tests/unit/EntityId/InMemoryEntityIdPagerTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Tests\EntityId;
+
+use PHPUnit\Framework\TestCase;
+use Wikibase\DataModel\Entity\ItemId;
+use Wikibase\DataModel\Services\EntityId\InMemoryEntityIdPager;
+
+/**
+ * @covers \Wikibase\DataModel\Services\EntityId\InMemoryEntityIdPager
+ *
+ * @license GPL-2.0-or-later
+ */
+class InMemoryEntityIdPagerTest extends TestCase {
+
+	public function testReturnsEmptyArrayWhenThereAreNoIds() {
+		$this->assertSame(
+			[],
+			( new InMemoryEntityIdPager() )->fetchIds( 10 )
+		);
+	}
+
+	public function testReturnsTheFirstIdsUpToLimit() {
+		$pager = new InMemoryEntityIdPager(
+			new ItemId( 'Q1' ),
+			new ItemId( 'Q2' ),
+			new ItemId( 'Q3' ),
+			new ItemId( 'Q4' ),
+			new ItemId( 'Q5' )
+		);
+
+		$this->assertEquals(
+			[
+				new ItemId( 'Q1' ),
+				new ItemId( 'Q2' ),
+			],
+			$pager->fetchIds( 2 )
+		);
+	}
+
+	public function testReturnsLessItemsIfThereAreFew() {
+		$pager = new InMemoryEntityIdPager(
+			new ItemId( 'Q1' ),
+			new ItemId( 'Q2' )
+		);
+
+		$this->assertEquals(
+			[
+				new ItemId( 'Q1' ),
+				new ItemId( 'Q2' ),
+			],
+			$pager->fetchIds( 5 )
+		);
+	}
+
+	public function testReturnsNextBatch() {
+		$pager = new InMemoryEntityIdPager(
+			new ItemId( 'Q1' ),
+			new ItemId( 'Q2' ),
+			new ItemId( 'Q3' ),
+			new ItemId( 'Q4' ),
+			new ItemId( 'Q5' )
+		);
+
+		$pager->fetchIds( 2 );
+
+		$this->assertEquals(
+			[
+				new ItemId( 'Q3' ),
+				new ItemId( 'Q4' ),
+			],
+			$pager->fetchIds( 2 )
+		);
+	}
+
+	public function testCanResumeFromPosition() {
+		$firstPager = new InMemoryEntityIdPager(
+			new ItemId( 'Q1' ),
+			new ItemId( 'Q2' ),
+			new ItemId( 'Q3' ),
+			new ItemId( 'Q4' ),
+			new ItemId( 'Q5' )
+		);
+
+		$secondPager = new InMemoryEntityIdPager(
+			new ItemId( 'Q1' ),
+			new ItemId( 'Q2' ),
+			new ItemId( 'Q3' ),
+			new ItemId( 'Q4' ),
+			new ItemId( 'Q5' )
+		);
+
+		$firstPager->fetchIds( 2 );
+		$secondPager->setPosition( $firstPager->getPosition() );
+
+		$this->assertEquals(
+			[
+				new ItemId( 'Q3' ),
+				new ItemId( 'Q4' ),
+			],
+			$secondPager->fetchIds( 2 )
+		);
+	}
+
+	public function testCanAddIds() {
+		$pager = new InMemoryEntityIdPager(
+			new ItemId( 'Q1' )
+		);
+
+		$pager->addEntityId( new ItemId( 'Q2' ) );
+
+		$this->assertEquals(
+			[
+				new ItemId( 'Q1' ),
+				new ItemId( 'Q2' ),
+			],
+			$pager->fetchIds( 2 )
+		);
+	}
+
+}


### PR DESCRIPTION
Part of https://phabricator.wikimedia.org/T219894
(though the ticket wont tell you anything about this commit)

In Wikibase Repo we have SqlEntityIdPager, which gets used by the
term rebuilding script. In the new term rebuilding script we need
the same stuff. To test that we need to inject a test double.
There is MockEntityIdPager, though it just implements EntityIdPager,
while our implementation needs extra methods from SqlEntityIdPager
that are not in the interface.

These extra methods are added in SeekableEntityIdPager.
InMemoryEntityIdPager is provided as test double and is a modified
version of MockEntityIdPager, which is now also tested.