### PR TITLE
Provide test double for ItemLookup and PropertyLookup

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -2,8 +2,12 @@
 
 ## Version 3.15.0 (dev)
 
-* Added `ItemLookup` test double by implementing it in `InMemoryEntityLookup`
-* Added `PropertyLookup` test double by implementing it in `InMemoryEntityLookup`
+* Added `ItemLookup` implementations
+  * `LegacyAdapterItemLookup` which is an adapter to `EntityLookup`
+  * `InMemoryEntityLookup` which is a test double
+* Added `PropertyLookup` implementations
+  * `LegacyAdapterPropertyLookup` which is an adapter to `EntityLookup`
+  * `InMemoryEntityLookup` which is a test double
 * Added constructor to `InMemoryEntityLookup`
 
 ## Version 3.14.0 (2019-04-16)

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -2,6 +2,8 @@
 
 ## Version 3.15.0 (dev)
 
+* Added `ItemLookup` test double by implementing it in `InMemoryEntityLookup`
+* Added `PropertyLookup` test double by implementing it in `InMemoryEntityLookup`
 * Added constructor to `InMemoryEntityLookup`
 
 ## Version 3.14.0 (2019-04-16)

--- a/src/Lookup/InMemoryEntityLookup.php
+++ b/src/Lookup/InMemoryEntityLookup.php
@@ -105,27 +105,11 @@ class InMemoryEntityLookup implements EntityLookup, ItemLookup, PropertyLookup {
 	}
 
 	public function getItemForId( ItemId $itemId ) {
-		try {
-			if ( $this->hasEntity( $itemId ) ) {
-				return $this->getEntity( $itemId );
-			}
-
-			return null;
-		} catch ( \Exception $ex ) {
-			throw new ItemLookupException( $itemId, $ex->getMessage(), $ex );
-		}
+		return ( new LegacyAdapterItemLookup( $this ) )->getItemForId( $itemId );
 	}
 
 	public function getPropertyForId( PropertyId $propertyId ) {
-		try {
-			if ( $this->hasEntity( $propertyId ) ) {
-				return $this->getEntity( $propertyId );
-			}
-
-			return null;
-		} catch ( \Exception $ex ) {
-			throw new PropertyLookupException( $propertyId, $ex->getMessage(), $ex );
-		}
+		return ( new LegacyAdapterPropertyLookup( $this ) )->getpropertyForId( $propertyId );
 	}
 
 }

--- a/src/Lookup/InMemoryEntityLookup.php
+++ b/src/Lookup/InMemoryEntityLookup.php
@@ -5,6 +5,8 @@ namespace Wikibase\DataModel\Services\Lookup;
 use InvalidArgumentException;
 use Wikibase\DataModel\Entity\EntityDocument;
 use Wikibase\DataModel\Entity\EntityId;
+use Wikibase\DataModel\Entity\ItemId;
+use Wikibase\DataModel\Entity\PropertyId;
 
 /**
  * EntityLookup that uses an in memory array to retrieve the requested information.
@@ -18,7 +20,7 @@ use Wikibase\DataModel\Entity\EntityId;
  * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-class InMemoryEntityLookup implements EntityLookup {
+class InMemoryEntityLookup implements EntityLookup, ItemLookup, PropertyLookup {
 
 	/**
 	 * @var EntityDocument[]
@@ -99,6 +101,30 @@ class InMemoryEntityLookup implements EntityLookup {
 	private function throwExceptionIfNeeded( EntityId $entityId ) {
 		if ( array_key_exists( $entityId->getSerialization(), $this->exceptions ) ) {
 			throw $this->exceptions[$entityId->getSerialization()];
+		}
+	}
+
+	public function getItemForId( ItemId $itemId ) {
+		try {
+			if ( $this->hasEntity( $itemId ) ) {
+				return $this->getEntity( $itemId );
+			}
+
+			return null;
+		} catch ( \Exception $ex ) {
+			throw new ItemLookupException( $itemId, $ex->getMessage(), $ex );
+		}
+	}
+
+	public function getPropertyForId( PropertyId $propertyId ) {
+		try {
+			if ( $this->hasEntity( $propertyId ) ) {
+				return $this->getEntity( $propertyId );
+			}
+
+			return null;
+		} catch ( \Exception $ex ) {
+			throw new PropertyLookupException( $propertyId, $ex->getMessage(), $ex );
 		}
 	}
 

--- a/src/Lookup/LegacyAdapterItemLookup.php
+++ b/src/Lookup/LegacyAdapterItemLookup.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Lookup;
+
+use Wikibase\DataModel\Entity\Item;
+use Wikibase\DataModel\Entity\ItemId;
+
+/**
+ * ItemLookup implementation providing a migration path away from
+ * the EntityLookup interface.
+ *
+ * @license GPL-2.0-or-later
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class LegacyAdapterItemLookup implements ItemLookup {
+
+	private $lookup;
+
+	public function __construct( EntityLookup $lookup ) {
+		$this->lookup = $lookup;
+	}
+
+	/**
+	 * @param ItemId $itemId
+	 *
+	 * @return Item|null
+	 * @throws ItemLookupException
+	 */
+	public function getItemForId( ItemId $itemId ) {
+		try {
+			return $this->lookup->getEntity( $itemId );
+		} catch ( EntityLookupException $ex ) {
+			throw new ItemLookupException( $itemId, $ex->getMessage(), $ex );
+		}
+	}
+
+}

--- a/src/Lookup/LegacyAdapterPropertyLookup.php
+++ b/src/Lookup/LegacyAdapterPropertyLookup.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Lookup;
+
+use Wikibase\DataModel\Entity\Property;
+use Wikibase\DataModel\Entity\PropertyId;
+
+/**
+ * PropertyLookup implementation providing a migration path away from
+ * the EntityLookup interface.
+ *
+ * @license GPL-2.0-or-later
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class LegacyAdapterPropertyLookup implements PropertyLookup {
+
+	private $lookup;
+
+	public function __construct( EntityLookup $lookup ) {
+		$this->lookup = $lookup;
+	}
+
+	/**
+	 * @param PropertyId $propertyId
+	 *
+	 * @return Property|null
+	 * @throws PropertyLookupException
+	 */
+	public function getPropertyForId( PropertyId $propertyId ) {
+		try {
+			return $this->lookup->getEntity( $propertyId );
+		} catch ( EntityLookupException $ex ) {
+			throw new PropertyLookupException( $propertyId, $ex->getMessage(), $ex );
+		}
+	}
+
+}

--- a/tests/fixtures/ItemFixtures.php
+++ b/tests/fixtures/ItemFixtures.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Fixtures;
+
+use Wikibase\DataModel\Entity\Item;
+use Wikibase\DataModel\Entity\ItemId;
+
+/**
+ * @license GPL-2.0-or-later
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class ItemFixtures {
+
+	public static function newItem() {
+		return new Item(
+			new ItemId( 'Q1' )
+		);
+	}
+
+}

--- a/tests/fixtures/PropertyFixtures.php
+++ b/tests/fixtures/PropertyFixtures.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Fixtures;
+
+use Wikibase\DataModel\Entity\Property;
+use Wikibase\DataModel\Entity\PropertyId;
+
+/**
+ * @license GPL-2.0-or-later
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class PropertyFixtures {
+
+	public static function newProperty() {
+		return new Property(
+			new PropertyId( 'P1' ),
+			null,
+			'string'
+		);
+	}
+
+}

--- a/tests/unit/Lookup/InMemoryEntityLookupTest.php
+++ b/tests/unit/Lookup/InMemoryEntityLookupTest.php
@@ -4,9 +4,14 @@ namespace Wikibase\DataModel\Services\Tests\Lookup;
 
 use InvalidArgumentException;
 use Wikibase\DataModel\Entity\ItemId;
+use Wikibase\DataModel\Entity\PropertyId;
 use Wikibase\DataModel\Services\Fixtures\FakeEntityDocument;
+use Wikibase\DataModel\Services\Fixtures\ItemFixtures;
+use Wikibase\DataModel\Services\Fixtures\PropertyFixtures;
 use Wikibase\DataModel\Services\Lookup\EntityLookupException;
 use Wikibase\DataModel\Services\Lookup\InMemoryEntityLookup;
+use Wikibase\DataModel\Services\Lookup\ItemLookupException;
+use Wikibase\DataModel\Services\Lookup\PropertyLookupException;
 
 /**
  * @covers \Wikibase\DataModel\Services\Lookup\InMemoryEntityLookup
@@ -85,6 +90,60 @@ class InMemoryEntityLookupTest extends \PHPUnit_Framework_TestCase {
 		new InMemoryEntityLookup(
 			new FakeEntityDocument()
 		);
+	}
+
+	public function testGivenKnownItem_getItemForIdReturnsIt() {
+		$item = ItemFixtures::newItem();
+
+		$lookup = new InMemoryEntityLookup( $item );
+
+		$this->assertEquals(
+			$item,
+			$lookup->getItemForId( $item->getId() )
+		);
+	}
+
+	public function testGivenKnownProperty_getPropertyForIdReturnsIt() {
+		$property = PropertyFixtures::newProperty();
+
+		$lookup = new InMemoryEntityLookup( $property );
+
+		$this->assertEquals(
+			$property,
+			$lookup->getPropertyForId( $property->getId() )
+		);
+	}
+
+	public function testWhenItemIsNotKnown_getItemForIdReturnsNull() {
+		$this->assertNull(
+			( new InMemoryEntityLookup() )->getItemForId( new ItemId( 'Q1' ) )
+		);
+	}
+
+	public function testWhenPropertyIsNotKnown_getPropertyForIdReturnsNull() {
+		$this->assertNull(
+			( new InMemoryEntityLookup() )->getPropertyForId( new PropertyId( 'P1' ) )
+		);
+	}
+
+	public function testGetItemForIdThrowsCorrectExceptionType() {
+		$id = new ItemId( 'Q1' );
+
+		$lookup = new InMemoryEntityLookup();
+		$lookup->addException( new EntityLookupException( $id ) );
+
+		$this->expectException( ItemLookupException::class );
+		$lookup->getItemForId( $id );
+	}
+
+	public function testGetPropertyForIdThrowsCorrectExceptionType() {
+		$id = new PropertyId( 'P1' );
+
+		$lookup = new InMemoryEntityLookup();
+		$lookup->addException( new EntityLookupException( $id ) );
+
+		$this->expectException( PropertyLookupException::class );
+		$lookup->getPropertyForId( $id );
 	}
 
 }

--- a/tests/unit/Lookup/LegacyAdapterItemLookupTest.php
+++ b/tests/unit/Lookup/LegacyAdapterItemLookupTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Tests\Lookup;
+
+use PHPUnit\Framework\TestCase;
+use Wikibase\DataModel\Entity\ItemId;
+use Wikibase\DataModel\Services\Fixtures\ItemFixtures;
+use Wikibase\DataModel\Services\Lookup\EntityLookupException;
+use Wikibase\DataModel\Services\Lookup\InMemoryEntityLookup;
+use Wikibase\DataModel\Services\Lookup\ItemLookupException;
+use Wikibase\DataModel\Services\Lookup\LegacyAdapterItemLookup;
+
+/**
+ * @covers \Wikibase\DataModel\Services\Lookup\LegacyAdapterItemLookup
+ *
+ * @license GPL-2.0-or-later
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class LegacyAdapterItemLookupTest extends TestCase {
+
+	public function testGivenKnownItem_getItemForIdReturnsIt() {
+		$item = ItemFixtures::newItem();
+
+		$lookup = new LegacyAdapterItemLookup( new InMemoryEntityLookup( $item ) );
+
+		$this->assertEquals(
+			$item,
+			$lookup->getItemForId( $item->getId() )
+		);
+	}
+
+	public function testWhenItemIsNotKnown_getItemForIdReturnsNull() {
+		$lookup = new LegacyAdapterItemLookup( new InMemoryEntityLookup() );
+
+		$this->assertNull(
+			$lookup->getItemForId( new ItemId( 'Q1' ) )
+		);
+	}
+
+	public function testGetItemForIdThrowsCorrectExceptionType() {
+		$id = new ItemId( 'Q1' );
+
+		$legacyLookup = new InMemoryEntityLookup();
+		$legacyLookup->addException( new EntityLookupException( $id ) );
+
+		$itemLookup = new LegacyAdapterItemLookup( $legacyLookup );
+
+		$this->expectException( ItemLookupException::class );
+		$itemLookup->getItemForId( $id );
+	}
+
+}

--- a/tests/unit/Lookup/LegacyAdapterPropertyLookupTest.php
+++ b/tests/unit/Lookup/LegacyAdapterPropertyLookupTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Tests\Lookup;
+
+use PHPUnit\Framework\TestCase;
+use Wikibase\DataModel\Entity\PropertyId;
+use Wikibase\DataModel\Services\Fixtures\PropertyFixtures;
+use Wikibase\DataModel\Services\Lookup\EntityLookupException;
+use Wikibase\DataModel\Services\Lookup\InMemoryEntityLookup;
+use Wikibase\DataModel\Services\Lookup\LegacyAdapterPropertyLookup;
+use Wikibase\DataModel\Services\Lookup\PropertyLookupException;
+
+/**
+ * @covers \Wikibase\DataModel\Services\Lookup\LegacyAdapterPropertyLookup
+ *
+ * @license GPL-2.0-or-later
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class LegacyAdapterPropertyLookupTest extends TestCase {
+
+	public function testGivenKnownProperty_getPropertyForIdReturnsIt() {
+		$property = PropertyFixtures::newProperty();
+
+		$lookup = new LegacyAdapterPropertyLookup( new InMemoryEntityLookup( $property ) );
+
+		$this->assertEquals(
+			$property,
+			$lookup->getPropertyForId( $property->getId() )
+		);
+	}
+
+	public function testWhenPropertyIsNotKnown_getPropertyForIdReturnsNull() {
+		$lookup = new LegacyAdapterPropertyLookup( new InMemoryEntityLookup() );
+
+		$this->assertNull(
+			$lookup->getPropertyForId( new PropertyId( 'P1' ) )
+		);
+	}
+
+	public function testGetPropertyForIdThrowsCorrectExceptionType() {
+		$id = new PropertyId( 'P1' );
+
+		$legacyLookup = new InMemoryEntityLookup();
+		$legacyLookup->addException( new EntityLookupException( $id ) );
+
+		$propertyLookup = new LegacyAdapterPropertyLookup( $legacyLookup );
+
+		$this->expectException( PropertyLookupException::class );
+		$propertyLookup->getPropertyForId( $id );
+	}
+
+}


### PR DESCRIPTION
https://phabricator.wikimedia.org/T219894

I'd like to change the constructor in https://gerrit.wikimedia.org/r/c/mediawiki/extensions/Wikibase/+/505670/1/repo/includes/Store/PropertyTermsRebuilder.php to take a PropertyLookup instead of an EntityLookup. Having a working test double for that would be nice in the tests.

Edit: also added adapters to EntityLookup now. This is the cheapest way to avoid our new code from binding to legacy interfaces.