### PR TITLE
Add FallbackLabelDescriptionLookup interface

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,9 @@
 # Wikibase DataModel Services release notes
 
+## Version 3.16.0 (dev)
+
+* Added `FallbackLabelDescriptionLookup` interface
+
 ## Version 3.15.0 (2019-04-24)
 
 * Added `ItemLookup` implementations

--- a/src/Lookup/FallbackLabelDescriptionLookup.php
+++ b/src/Lookup/FallbackLabelDescriptionLookup.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Lookup;
+
+use Wikibase\DataModel\Entity\EntityId;
+use Wikibase\DataModel\Term\TermFallback;
+
+/**
+ * A {@link LabelDescriptionLookup} that is guaranteed to return
+ * {@link TermFallback}s, not merely {@link Term}s.
+ *
+ * @since 3.16.0
+ *
+ * @license GPL-2.0-or-later
+ */
+interface FallbackLabelDescriptionLookup extends LabelDescriptionLookup {
+
+	/**
+	 * @param EntityId $entityId
+	 *
+	 * @throws LabelDescriptionLookupException
+	 * @return TermFallback|null
+	 */
+	public function getLabel( EntityId $entityId );
+
+	/**
+	 * @param EntityId $entityId
+	 *
+	 * @throws LabelDescriptionLookupException
+	 * @return TermFallback|null
+	 */
+	public function getDescription( EntityId $entityId );
+
+}


### PR DESCRIPTION
This is an interface for LabelDescriptionLookup implementations that always return TermFallback instances, since some code likes to rely on the more specific return type. It was originally introduced in Wikibase change [Ie39f06bb33][1] and is now copied into this library.

[1]: https://gerrit.wikimedia.org/r/520902