### PR TITLE
Follow the chain in the double redirects

### DIFF
--- a/src/Lookup/RedirectResolvingEntityLookup.php
+++ b/src/Lookup/RedirectResolvingEntityLookup.php
@@ -86,9 +86,9 @@ class RedirectResolvingEntityLookup implements EntityLookup {
 
 			// Try one more time
 			try {
-				$this->lookup->hasEntity( $ex->getRedirectTargetId() );
+				return $this->lookup->hasEntity( $ex->getRedirectTargetId() );
 			} catch ( UnresolvedEntityRedirectException $ex2 ) {
-				$this->lookup->hasEntity( $ex2->getRedirectTargetId() );
+				return $this->lookup->hasEntity( $ex2->getRedirectTargetId() );
 			}
 		}
 	}

--- a/src/Lookup/RedirectResolvingEntityLookup.php
+++ b/src/Lookup/RedirectResolvingEntityLookup.php
@@ -50,7 +50,17 @@ class RedirectResolvingEntityLookup implements EntityLookup {
 		try {
 			return $this->lookup->getEntity( $entityId );
 		} catch ( UnresolvedEntityRedirectException $ex ) {
-			return $this->lookup->getEntity( $ex->getRedirectTargetId() );
+			// Avoid self-redirects
+			if ( $ex->getRedirectTargetId() === $entityId ) {
+				throw $ex;
+			}
+
+			// Try one more time
+			try {
+				return $this->lookup->getEntity( $ex->getRedirectTargetId() );
+			} catch ( UnresolvedEntityRedirectException $ex2 ) {
+				return $this->lookup->getEntity( $ex2->getRedirectTargetId() );
+			}
 		}
 	}
 
@@ -69,7 +79,17 @@ class RedirectResolvingEntityLookup implements EntityLookup {
 		try {
 			return $this->lookup->hasEntity( $entityId );
 		} catch ( UnresolvedEntityRedirectException $ex ) {
-			return $this->lookup->hasEntity( $ex->getRedirectTargetId() );
+			// Avoid self-redirects
+			if ( $ex->getRedirectTargetId() === $entityId ) {
+				throw $ex;
+			}
+
+			// Try one more time
+			try {
+				$this->lookup->hasEntity( $ex->getRedirectTargetId() );
+			} catch ( UnresolvedEntityRedirectException $ex2 ) {
+				$this->lookup->hasEntity( $ex2->getRedirectTargetId() );
+			}
 		}
 	}
 

--- a/tests/unit/Lookup/RedirectResolvingEntityLookupTest.php
+++ b/tests/unit/Lookup/RedirectResolvingEntityLookupTest.php
@@ -62,6 +62,7 @@ class RedirectResolvingEntityLookupTest extends TestCase {
 		return [
 			'no redirect' => [ new ItemId( 'Q10' ), new ItemId( 'Q10' ) ],
 			'one redirect' => [ new ItemId( 'Q11' ), new ItemId( 'Q10' ) ],
+			'double redirect' => [ new ItemId( 'Q12' ), new ItemId( 'Q10' ) ],
 		];
 	}
 
@@ -94,20 +95,12 @@ class RedirectResolvingEntityLookupTest extends TestCase {
 		$this->assertNull( $lookup->getEntity( $id ) );
 	}
 
-	public function testGetEntity_doubleRedirect() {
-		$lookup = new RedirectResolvingEntityLookup( $this->getLookupDouble() );
-
-		$id = new ItemId( 'Q12' ); // Q12 is a double redirect
-
-		$this->setExpectedException( UnresolvedEntityRedirectException::class );
-		$lookup->getEntity( $id );
-	}
-
 	public function hasEntityProvider() {
 		return [
 			'unknown entity' => [ new ItemId( 'Q7' ), false ],
 			'no redirect' => [ new ItemId( 'Q10' ), true ],
 			'one redirect' => [ new ItemId( 'Q11' ), true ],
+			'double redirect' => [ new ItemId( 'Q12' ), true ],
 			'broken redirect' => [ new ItemId( 'Q21' ), false ],
 		];
 	}


### PR DESCRIPTION
Double redirects are quite a common thing in Wikimedia, refusing
to resolve them will cause lots of production fatals.

Bug: [T228996](https://phabricator.wikimedia.org/T228996)