### PR TITLE
Stop accepting null for term type and lang in TermBuffer::prefetchTerms()

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,8 @@
 # Wikibase DataModel Services release notes
 
+## Version 5.0.0 (dev)
+* Stopped accepting null for term type or language in TermBuffer::prefetchTerms()
+
 ## Version 4.0.0 (2020-01-06)
 
 * Added `FallbackLabelDescriptionLookup` interface

--- a/src/Term/TermBuffer.php
+++ b/src/Term/TermBuffer.php
@@ -19,10 +19,10 @@ interface TermBuffer {
 	 * The source from which to fetch would typically be supplied to the buffer's constructor.
 	 *
 	 * @param EntityId[] $entityIds
-	 * @param string[]|null $termTypes The desired term types; null means all.
-	 * @param string[]|null $languageCodes The desired languages; null means all.
+	 * @param string[] $termTypes The desired term types.
+	 * @param string[] $languageCodes The desired languages.
 	 */
-	public function prefetchTerms( array $entityIds, array $termTypes = null, array $languageCodes = null );
+	public function prefetchTerms( array $entityIds, array $termTypes, array $languageCodes );
 
 	/**
 	 * Returns a term that was previously loaded by prefetchTerms.


### PR DESCRIPTION
It has caused more harm than good. Lots of places load all terms to
use very small bits of it. They are fixed now.