### PR TITLE
Simplify ByPropertyIdGrouper::addPropertyIdProvider()

### DIFF
--- a/src/ByPropertyIdGrouper.php
+++ b/src/ByPropertyIdGrouper.php
@@ -58,12 +58,7 @@ class ByPropertyIdGrouper {
 
 	private function addPropertyIdProvider( PropertyIdProvider $propertyIdProvider ) {
 		$idSerialization = $propertyIdProvider->getPropertyId()->getSerialization();
-
-		if ( isset( $this->byPropertyId[$idSerialization] ) ) {
-			$this->byPropertyId[$idSerialization][] = $propertyIdProvider;
-		} else {
-			$this->byPropertyId[$idSerialization] = [ $propertyIdProvider ];
-		}
+		$this->byPropertyId[$idSerialization][] = $propertyIdProvider;
 	}
 
 	/**


### PR DESCRIPTION
PHP automatically initializes arrays as empty when the `$array[] = $value` syntax is used to append to them, so there’s no need for the explicit `isset()` check or initialization.