### PR TITLE
Document language fallback behavior of interfaces

### DIFF
--- a/src/Lookup/LabelDescriptionLookup.php
+++ b/src/Lookup/LabelDescriptionLookup.php
@@ -6,6 +6,11 @@ use Wikibase\DataModel\Entity\EntityId;
 use Wikibase\DataModel\Term\Term;
 
 /**
+ * Looks up the label or description of an entity.
+ *
+ * Like for {@link LabelLookup},
+ * implementations may or may not apply language fallbacks.
+ *
  * @since 1.1
  *
  * @license GPL-2.0-or-later

--- a/src/Lookup/LabelDescriptionLookup.php
+++ b/src/Lookup/LabelDescriptionLookup.php
@@ -9,7 +9,7 @@ use Wikibase\DataModel\Term\Term;
  * Looks up the label or description of an entity.
  *
  * Like for {@link LabelLookup},
- * implementations may or may not apply language fallbacks.
+ * it depends on the implementation whether language fallbacks are applied or not.
  *
  * @since 1.1
  *

--- a/src/Lookup/LabelLookup.php
+++ b/src/Lookup/LabelLookup.php
@@ -6,6 +6,13 @@ use Wikibase\DataModel\Entity\EntityId;
 use Wikibase\DataModel\Term\Term;
 
 /**
+ * Looks up the label of an entity.
+ *
+ * The language used is typically determined when the service is constructed,
+ * such as the content or interface language.
+ * Whether language fallbacks are applied or not depends on the implementation.
+ * (To look up labels in specific languages, without fallbacks, use {@link TermLookup}.)
+ *
  * @since 3.10
  *
  * @license GPL-2.0-or-later

--- a/src/Lookup/TermLookup.php
+++ b/src/Lookup/TermLookup.php
@@ -7,6 +7,9 @@ use Wikibase\DataModel\Entity\EntityId;
 /**
  * A service interface for looking up entity terms.
  *
+ * This service only looks up terms in the specified language(s)
+ * and does not apply language fallbacks.
+ *
  * @note: A TermLookup cannot be used to determine whether an entity exists or not.
  *
  * @since 1.1

--- a/src/Term/TermBuffer.php
+++ b/src/Term/TermBuffer.php
@@ -7,6 +7,9 @@ use Wikibase\DataModel\Entity\EntityId;
 /**
  * A service interface for buffering terms.
  *
+ * Typically implemented in conjunction with {@link TermLookup},
+ * and (like that interface) does not apply language fallbacks.
+ *
  * @since 1.1
  *
  * @license GPL-2.0-or-later


### PR DESCRIPTION
Previously, it wasn’t clear whether these interfaces are supposed to apply language fallbacks or not. From the existing implementations in Wikibase, it seems that `TermLookup` and `TermBuffer` are intended only to look up terms in specific languages (without fallbacks), whereas `LabelLookup` and `LabelDescriptionLookup` may or may not apply fallbacks – implementations include `LanguageLabelDescriptionLookup` (no fallbacks) and `LanguageFallbackLabelDescriptionLookup` (fallbacks).

Bug: [T266145](https://phabricator.wikimedia.org/T266145)