### PR TITLE
Add `EntityRedirectLookup::FOR_UPDATE`

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,8 @@
 # Wikibase DataModel Services release notes
 
+## Version 5.4.0 (under development)
+* Added `EntityRedirectLookup::FOR_UPDATE` constant
+
 ## Version 5.3.0 (2020-03-10)
 * Allow installing with data-values/data-values 3.0.0
 

--- a/src/Lookup/EntityRedirectLookup.php
+++ b/src/Lookup/EntityRedirectLookup.php
@@ -15,6 +15,11 @@ use Wikibase\DataModel\Entity\EntityId;
 interface EntityRedirectLookup {
 
 	/**
+	 * @since 5.4
+	 */
+	public const FOR_UPDATE = 'for update';
+
+	/**
 	 * Returns the IDs of the entities that redirect to (are aliases of) the given target entity.
 	 *
 	 * @since 2.0
@@ -32,7 +37,7 @@ interface EntityRedirectLookup {
 	 * @since 2.0
 	 *
 	 * @param EntityId $entityId
-	 * @param string $forUpdate If "for update" is given the redirect will be
+	 * @param string $forUpdate If EntityRedirectLookup::FOR_UPDATE is given the redirect will be
 	 *        determined from the canonical master database.
 	 *
 	 * @return EntityId|null The ID of the redirect target, or null if $entityId does not refer to a


### PR DESCRIPTION
This allows us to use the constant [in implementations](https://github.com/wikimedia/Wikibase/blob/ab4b5817518539ebec04781972a2749a5d63f710/repo/includes/Store/Sql/WikiPageEntityRedirectLookup.php#L121) and saves us from scary typos.

Bug: T280771