### PR TITLE
Extract EntityRedirectTargetLookup from EntityRedirectLookup

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -2,6 +2,7 @@
 
 ## Version 5.4.0 (under development)
 * Added `EntityRedirectLookup::FOR_UPDATE` constant
+* Added `EntityRedirectTargetLookup` (extracted from `EntityRedirectLookup`)
 
 ## Version 5.3.0 (2020-03-10)
 * Allow installing with data-values/data-values 3.0.0

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,6 +1,6 @@
 # Wikibase DataModel Services release notes
 
-## Version 5.4.0 (under development)
+## Version 5.4.0 (2021-04-23)
 * Added `EntityRedirectLookup::FOR_UPDATE` constant
 * Added `EntityRedirectTargetLookup` (extracted from `EntityRedirectLookup`)
 

--- a/src/Lookup/EntityRedirectLookup.php
+++ b/src/Lookup/EntityRedirectLookup.php
@@ -12,12 +12,7 @@ use Wikibase\DataModel\Entity\EntityId;
  * @license GPL-2.0-or-later
  * @author Daniel Kinzler
  */
-interface EntityRedirectLookup {
-
-	/**
-	 * @since 5.4
-	 */
-	public const FOR_UPDATE = 'for update';
+interface EntityRedirectLookup extends EntityRedirectTargetLookup {
 
 	/**
 	 * Returns the IDs of the entities that redirect to (are aliases of) the given target entity.
@@ -30,20 +25,5 @@ interface EntityRedirectLookup {
 	 * @throws EntityRedirectLookupException
 	 */
 	public function getRedirectIds( EntityId $targetId );
-
-	/**
-	 * Returns the redirect target associated with the given redirect ID.
-	 *
-	 * @since 2.0
-	 *
-	 * @param EntityId $entityId
-	 * @param string $forUpdate If EntityRedirectLookup::FOR_UPDATE is given the redirect will be
-	 *        determined from the canonical master database.
-	 *
-	 * @return EntityId|null The ID of the redirect target, or null if $entityId does not refer to a
-	 * redirect.
-	 * @throws EntityRedirectLookupException
-	 */
-	public function getRedirectForEntityId( EntityId $entityId, $forUpdate = '' );
 
 }

--- a/src/Lookup/EntityRedirectTargetLookup.php
+++ b/src/Lookup/EntityRedirectTargetLookup.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Wikibase\DataModel\Services\Lookup;
+
+use Wikibase\DataModel\Entity\EntityId;
+
+/**
+ * Service interface for looking up an Entity's redirect target id.
+ *
+ * @since 5.4
+ *
+ * @license GPL-2.0-or-later
+ */
+interface EntityRedirectTargetLookup {
+
+	/**
+	 * @since 5.4
+	 */
+	public const FOR_UPDATE = 'for update';
+
+	/**
+	 * Returns the redirect target associated with the given redirect ID.
+	 *
+	 * @since 2.0
+	 *
+	 * @param EntityId $entityId
+	 * @param string $forUpdate If EntityRedirectTargetLookup::FOR_UPDATE is given the redirect will be
+	 *        determined from the canonical master database.
+	 *
+	 * @return EntityId|null The ID of the redirect target, or null if $entityId does not refer to a
+	 * redirect.
+	 * @throws EntityRedirectLookupException
+	 */
+	public function getRedirectForEntityId( EntityId $entityId, $forUpdate = '' );
+
+}


### PR DESCRIPTION
In some cases (see T280771) we only need to find redirect targets and
don't need EntityRedirectLookup::getRedirectIds. In order to not add
unnecessary implementations or violate the interface-segregation
principle EntityRedirectTargetLookup provides only the redirect ->
redirect target part of the interface.

Bug: T280771