### PR TITLE
Composer update to support PHP >8.1.

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,6 +1,6 @@
 build:
   environment:
-    php: 7.2
+    php: 8.1
 
 inherit: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,9 @@ dist: xenial
 matrix:
   fast_finish: true
   include:
-    - php: 7.2
-    - php: 7.3
     - php: 7.4
     - php: 8.0
+    - php: 8.1
 
 sudo: false
 

--- a/composer.json
+++ b/composer.json
@@ -26,12 +26,12 @@
 	"repositories": {
 		"wikibase-datamodel": {
 			"type": "vcs",
-			"url": "https://github.com/aurelie1vndl/WikibaseDataModel.git"
+			"url": "https://github.com/makeitfly/WikibaseDataModel.git"
 		}
 	},
 	"require": {
 		"php": ">=7.2",
-		"wikibase/data-model": "~9.0|~8.0",
+		"data-values/data-values": "~3.0",
 		"wikibase/data-model": "dev-master",
 		"diff/diff": "~3.2",
 		"wikimedia/assert": "~0.2.2|~0.3.0|~0.4.0|~0.5.0"

--- a/composer.json
+++ b/composer.json
@@ -23,22 +23,16 @@
 	"support": {
 		"irc": "irc://irc.libera.chat/wikidata"
 	},
-	"repositories": {
-		"wikibase-datamodel": {
-			"type": "vcs",
-			"url": "https://github.com/makeitfly/WikibaseDataModel.git"
-		}
-	},
 	"require": {
-		"php": ">=7.2",
+		"php": ">=8.1",
+		"wikibase/data-model": "dev-master#cbbdfcb13e026357f7d441b9c901f06263304e46",
 		"data-values/data-values": "~3.0",
-		"wikibase/data-model": "dev-master",
 		"diff/diff": "~3.2",
 		"wikimedia/assert": "~0.2.2|~0.3.0|~0.4.0|~0.5.0"
 	},
 	"require-dev": {
 		"phpmd/phpmd": "~2.3",
-		"phpunit/phpunit": "~8.0"
+		"phpunit/phpunit": "~9"
 	},
 	"autoload": {
 		"psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -23,10 +23,16 @@
 	"support": {
 		"irc": "irc://irc.libera.chat/wikidata"
 	},
+	"repositories": {
+		"wikibase-datamodel": {
+			"type": "vcs",
+			"url": "https://github.com/aurelie1vndl/WikibaseDataModel.git"
+		}
+	},
 	"require": {
 		"php": ">=7.2",
 		"wikibase/data-model": "~9.0|~8.0",
-		"data-values/data-values": "^3.1.0",
+		"wikibase/data-model": "dev-master",
 		"diff/diff": "~3.2",
 		"wikimedia/assert": "~0.2.2|~0.3.0|~0.4.0|~0.5.0"
 	},


### PR DESCRIPTION
```
➜ ./vendor/bin/phpunit tests
PHPUnit 9.6.20 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.1.29
Configuration: /WikibaseDataModelServices/phpunit.xml.dist
Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

...............................................................  63 / 452 ( 13%)
............................................................... 126 / 452 ( 27%)
............................................................... 189 / 452 ( 41%)
............................................................... 252 / 452 ( 55%)
............................................................... 315 / 452 ( 69%)
............................................................... 378 / 452 ( 83%)
............................................................... 441 / 452 ( 97%)
...........                                                     452 / 452 (100%)

Time: 00:00.046, Memory: 12.00 MB

OK (452 tests, 736 assertions)
```